### PR TITLE
Fix doc.md typo?

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -1,6 +1,6 @@
 # Help to use the civo terraform provider
 
-## Leyend
+## Legend
 
 - ``#`` (optional parameter)
 


### PR DESCRIPTION
I'm assuming that "leyend" was supposed to say legend but I'm not sure.