### PR TITLE
Edit Kubernetes  provider markdown mistype

### DIFF
--- a/website/docs/d/kubernetes_version.html.markdown
+++ b/website/docs/d/kubernetes_version.html.markdown
@@ -15,7 +15,7 @@ Provides access to the available Civo Kubernetes Service versions, with the abil
 ```hcl
 data "civo_kubernetes_version" "stable" {
     filter {
-        name = "type"
+        key = "type"
         values = ["stable"]
     }
 }


### PR DESCRIPTION
It should be key, doesn't work with name = "type"