### PR TITLE
Terraform 0.12 required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform Provider ![Travis build](https://travis-ci.org/civo/terraform-provider
 Requirements
 ------------
 
--   [Terraform](https://www.terraform.io/downloads.html) 0.13.x
+-   [Terraform](https://www.terraform.io/downloads.html) 0.12.x
 -   [Go](https://golang.org/doc/install) 1.13 (to build the provider plugin)
 
 Building The Provider


### PR DESCRIPTION
As mentioned in #17 (why is it closed?), provider Civo doesn't work with Terraform 0.13.x so as long as Civo is not listed in the Terraform registry, knowing that you have to use 0.12 will be helpful for anybody trying this good stuff.