### PR TITLE
fix(README): Fixed unauthenticated download in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Clone repository to: `$GOPATH/src/github.com/civo/terraform-provider-civo`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/terraform-providers; cd $GOPATH/src/github.com/terraform-providers
-$ git clone git@github.com:terraform-providers/terraform-provider-civo
+$ git clone https://github.com/civo/terraform-provider-civo.git
 ```
 
 Enter the provider directory and build the provider


### PR DESCRIPTION
The official README does not have a valid repository URL and should really be changed to HTTPS 