### PR TITLE
Fixed 'applications' argument's description and corresponding examples.

### DIFF
--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -63,7 +63,9 @@ func resourceKubernetesCluster() *schema.Resource {
 				Optional: true,
 				Description: "a comma separated list of applications to install." +
 					"Spaces within application names are fine, but shouldn't be either side of the comma." +
-					"If you want to remove a default installed application, prefix it with a '-', e.g. -traefik.",
+					"Application names are case-sensitive; the available applications can be listed with the civo CLI:" +
+					"'civo kubernetes applications ls'." +
+					"If you want to remove a default installed application, prefix it with a '-', e.g. -Traefik.",
 			},
 			// Computed resource
 			"instances":              instanceSchema(),

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -16,7 +16,7 @@ Provides a Civo Kubernetes cluster resource. This can be used to create, delete,
 
 resource "civo_kubernetes_cluster" "my-cluster" {
     name = "my-cluster"
-    applications = "Portainer, Traefik"
+    applications = "Portainer,Traefik"
     num_target_nodes = 4
     target_nodes_size = element(data.civo_instances_size.small.sizes, 0).name
 }
@@ -31,7 +31,7 @@ The cluster's kubeconfig is exported as an attribute allowing you to use it with
 resource "civo_kubernetes_cluster" "my-cluster" {
     name = "my-cluster"
     region = "NYC1"
-    applications = "Portainer, Traefik"
+    applications = "Portainer,Traefik"
     num_target_nodes = 4
     target_nodes_size = element(data.civo_instances_size.small.sizes, 0).name
 }
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `target_nodes_size` - (Optional) The size of each node (The default is currently g3.k3s.small)
 * `kubernetes_version` - (Optional) The version of k3s to install (The default is currently the latest available).
 * `tags` - (Optional) A space separated list of tags, to be used freely as required.
-* `applications` - (Optional) A comma separated list of applications to install. Spaces within application names are fine, but shouldn't be either side of the comma. If you want to remove a default installed application, prefix it with a '-', e.g. -traefik
+* `applications` - (Optional) A comma separated list of applications to install. Spaces within application names are fine, but shouldn't be either side of the comma. Application names are case-sensitive; the available applications can be listed with the civo CLI: 'civo kubernetes applications ls'. If you want to remove a default installed application, prefix it with a '-', e.g. -Traefik
 
 ## Attributes Reference
 


### PR DESCRIPTION
In the civo_kubernetes_cluster's documentation: 

- The example to remove the default Traefik application wouldn't work ("-traefik") because the app names are case sensitive, so it needs to be "-Traefik". 
- I also added a generic mention for case-sensitivity, and a civo CLI example to list the available applications. 
- Also in the HCL example I removed the space after the "," as the application documentation requires it.

I made the doc updates in both the documentation (markdown) file and the provider file (go).