### PR TITLE
Docs update for Kubernetes provider example

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -37,13 +37,10 @@ resource "civo_kubernetes_cluster" "my-cluster" {
 }
 
 provider "kubernetes" {
-  load_config_file = false
   host  = civo_kubernetes_cluster.my-cluster.api_endpoint
-  username = yamldecode(civo_kubernetes_cluster.my-cluster.kubeconfig).users[0].user.username
-  password = yamldecode(civo_kubernetes_cluster.my-cluster.kubeconfig).users[0].user.password
-  cluster_ca_certificate = base64decode(
-    yamldecode(civo_kubernetes_cluster.my-cluster.kubeconfig).clusters[0].cluster.certificate-authority-data
-  )
+  client_certificate     = base64decode(yamldecode(civo_kubernetes_cluster.my-cluster.kubeconfig).users[0].user.client-certificate-data)
+  client_key             = base64decode(yamldecode(civo_kubernetes_cluster.my-cluster.kubeconfig).users[0].user.client-key-data)
+  cluster_ca_certificate = base64decode(yamldecode(civo_kubernetes_cluster.my-cluster.kubeconfig).clusters[0].cluster.certificate-authority-data)
 }
 ```
 


### PR DESCRIPTION
The previous `load_config_file`, `username` and `password` are not working. I'm not sure if they used to work before.

We have to use `client_certificate` and `client_key` together with current `cluster_ca_certificate` now. And they need to be base64 decoded.

References:

- https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#credentials-config
- https://www.terraform.io/docs/language/functions/base64decode.html