### PR TITLE
Mark IaaS password as sensitive

### DIFF
--- a/civo/resource_instance.go
+++ b/civo/resource_instance.go
@@ -119,8 +119,9 @@ func resourceInstance() *schema.Resource {
 				Computed: true,
 			},
 			"initial_password": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"private_ip": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Closes #51

---

`tf show` output **before** this PR

<details>
  <summary>Show</summary>
  
  ```
  # civo_instance.my-test-instance:
resource "civo_instance" "my-test-instance" {
    cpu_cores          = 1
    created_at         = "0001-01-01 00:00:00 +0000 UTC"
    disk_gb            = 15
    firewall_id        = "c1ce01cf-5e01-4378-8f03-f93a45d31843"
    hostname           = "foo.com"
    id                 = "77728c16-40fc-4fa0-87a7-9cc2b50116c3"
    initial_password   = "X7TepMCRE5Y4"
    initial_user       = "civo"
    network_id         = "fb3cdfff-66ba-4048-9f37-8625237cbe67"
    notes              = "this is a note for the server"
    private_ip         = "192.168.1.11"
    public_ip          = "212.2.246.134"
    public_ip_required = "create"
    ram_mb             = 1024
    size               = "g3.k3s.xsmall"
    source_id          = "debian-10"
    source_type        = "diskimage"
    status             = "ACTIVE"
    tags               = [
        "nginx",
        "python",
    ]
    template           = "4204229c-510c-4ba4-ab07-522e2aaa2cf8"
}

# data.civo_instances_size.small:
data "civo_instances_size" "small" {
    id    = "terraform-20210812065529146100000001"
    sizes = [
        {
            cpu         = 1
            description = "Extra Small"
            disk        = 15
            name        = "g3.k3s.xsmall"
            ram         = 1024
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 1
            description = "Small"
            disk        = 15
            name        = "g3.k3s.small"
            ram         = 2048
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 2
            description = "Medium"
            disk        = 15
            name        = "g3.k3s.medium"
            ram         = 4096
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 4
            description = "Large"
            disk        = 15
            name        = "g3.k3s.large"
            ram         = 8192
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 6
            description = "Extra Large"
            disk        = 15
            name        = "g3.k3s.xlarge"
            ram         = 16384
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 8
            description = "2X Large"
            disk        = 15
            name        = "g3.k3s.2xlarge"
            ram         = 32768
            selectable  = true
            type        = "kubernetes"
        },
    ]

    filter {
        all      = false
        key      = "type"
        match_by = "exact"
        values   = [
            "kubernetes",
        ]
    }

    sort {
        direction = "asc"
        key       = "ram"
    }
}

# data.civo_template.debian:
data "civo_template" "debian" {
    id        = "terraform-20210812065529796300000002"
    templates = [
        {
            id      = "4204229c-510c-4ba4-ab07-522e2aaa2cf8"
            label   = ""
            name    = "debian-10"
            version = "10"
        },
    ]

    filter {
        all      = false
        key      = "name"
        match_by = "exact"
        values   = [
            "debian-10",
        ]
    }
}
  ```
</details>

---

`tf show` output **after** this PR

<details>
  <summary>Show</summary>
  
  ```
  # civo_instance.my-test-instance:
resource "civo_instance" "my-test-instance" {
    cpu_cores          = 1
    created_at         = "0001-01-01 00:00:00 +0000 UTC"
    disk_gb            = 15
    firewall_id        = "c1ce01cf-5e01-4378-8f03-f93a45d31843"
    hostname           = "foo.com"
    id                 = "661d8e92-4272-4d2f-b47d-96594abf8447"
    initial_password   = (sensitive value)
    initial_user       = "civo"
    network_id         = "fb3cdfff-66ba-4048-9f37-8625237cbe67"
    notes              = "this is a note for the server"
    private_ip         = "192.168.1.11"
    public_ip          = "212.2.241.167"
    public_ip_required = "create"
    ram_mb             = 1024
    size               = "g3.k3s.xsmall"
    source_id          = "debian-10"
    source_type        = "diskimage"
    status             = "ACTIVE"
    tags               = [
        "nginx",
        "python",
    ]
    template           = "4204229c-510c-4ba4-ab07-522e2aaa2cf8"
}

# data.civo_instances_size.small:
data "civo_instances_size" "small" {
    id    = "terraform-20210812070520186600000001"
    sizes = [
        {
            cpu         = 1
            description = "Extra Small"
            disk        = 15
            name        = "g3.k3s.xsmall"
            ram         = 1024
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 1
            description = "Small"
            disk        = 15
            name        = "g3.k3s.small"
            ram         = 2048
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 2
            description = "Medium"
            disk        = 15
            name        = "g3.k3s.medium"
            ram         = 4096
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 4
            description = "Large"
            disk        = 15
            name        = "g3.k3s.large"
            ram         = 8192
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 6
            description = "Extra Large"
            disk        = 15
            name        = "g3.k3s.xlarge"
            ram         = 16384
            selectable  = true
            type        = "kubernetes"
        },
        {
            cpu         = 8
            description = "2X Large"
            disk        = 15
            name        = "g3.k3s.2xlarge"
            ram         = 32768
            selectable  = true
            type        = "kubernetes"
        },
    ]

    filter {
        all      = false
        key      = "type"
        match_by = "exact"
        values   = [
            "kubernetes",
        ]
    }

    sort {
        direction = "asc"
        key       = "ram"
    }
}

# data.civo_template.debian:
data "civo_template" "debian" {
    id        = "terraform-20210812070520755100000002"
    templates = [
        {
            id      = "4204229c-510c-4ba4-ab07-522e2aaa2cf8"
            label   = ""
            name    = "debian-10"
            version = "10"
        },
    ]

    filter {
        all      = false
        key      = "name"
        match_by = "exact"
        values   = [
            "debian-10",
        ]
    }
}
  ```
</details>


**Note**:
Outputs above were from two different IaaS nodes