### PR TITLE
Fix "empty non-retryable error received" error when updating IaaS node size

### DIFF
--- a/civo/resource_instance.go
+++ b/civo/resource_instance.go
@@ -42,7 +42,7 @@ func resourceInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "g3.xsmall",
-				Description: "The name of the size, from the current list, e.g. g2.small (required)",
+				Description: "The name of the size, from the current list, e.g. g3.xsmall",
 			},
 			"public_ip_required": {
 				Type:        schema.TypeString,
@@ -365,7 +365,12 @@ func resourceInstanceUpdate(d *schema.ResourceData, m interface{}) error {
 				return resource.RetryableError(fmt.Errorf("[ERR] expected instance to be resizing but was in state %s", resp.Status))
 			}
 
-			return resource.NonRetryableError(resourceInstanceRead(d, m))
+			err = resourceInstanceRead(d, m)
+			if err != nil {
+				return resource.NonRetryableError(err)
+			}
+
+			return nil
 		})
 	}
 


### PR DESCRIPTION
Closes #53

<details>
  <summary>Show outputs when testing this PR</summary>
  
  ```
   ~/civo/test-civo-terraform-provider ᐅ ls -la
total 16
drwxr-xr-x   6 zulh  staff  192 Aug 13 15:49 .
drwxr-xr-x  29 zulh  staff  928 Aug  5 11:31 ..
drwxr-xr-x   3 zulh  staff   96 Aug  9 10:06 .terraform
drwxr-xr-x   3 zulh  staff   96 Aug  9 10:33 .terraform.d
-rw-r--r--   1 zulh  staff  234 Aug 13 15:49 main.tf
-rw-r--r--   1 zulh  staff  355 Aug 13 12:38 provider.tf
 
~/civo/test-civo-terraform-provider ᐅ cat main.tf
resource "civo_instance" "my-test-instance" {
    hostname = "kubeform-test"
    tags = ["python", "nginx"]
    notes = "this is a note for the server"
    # size = "g3.large"
    template = "8eb48e20-e5db-49fe-9cdf-cc8f381c61c6"
}
 
~/civo/test-civo-terraform-provider ᐅ tf init
2021-08-13T15:50:12.807+0800 [INFO]  Terraform version: 1.0.3
2021-08-13T15:50:12.807+0800 [INFO]  Go runtime version: go1.16.4
2021-08-13T15:50:12.807+0800 [INFO]  CLI args: []string{"/usr/local/bin/terraform", "init"}
2021-08-13T15:50:12.807+0800 [INFO]  Loading CLI configuration from /Users/zulh/.terraformrc
2021-08-13T15:50:12.808+0800 [INFO]  CLI command args: []string{"init"}

Initializing the backend...
2021-08-13T15:50:12.814+0800 [INFO]  Failed to read plugin lock file .terraform/plugins/darwin_amd64/lock.json: open .terraform/plugins/darwin_amd64/lock.json: no such file or directory

Initializing provider plugins...
- Finding civo/civo versions matching "99.0.0"...
- Installing civo/civo v99.0.0...
- Installed civo/civo v99.0.0 (unauthenticated)

Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
 
~/civo/test-civo-terraform-provider ᐅ tf apply --auto-approve
2021-08-13T15:50:23.170+0800 [INFO]  Terraform version: 1.0.3
2021-08-13T15:50:23.170+0800 [INFO]  Go runtime version: go1.16.4
2021-08-13T15:50:23.170+0800 [INFO]  CLI args: []string{"/usr/local/bin/terraform", "apply", "--auto-approve"}
2021-08-13T15:50:23.170+0800 [INFO]  Loading CLI configuration from /Users/zulh/.terraformrc
2021-08-13T15:50:23.172+0800 [INFO]  CLI command args: []string{"apply", "--auto-approve"}
2021-08-13T15:50:23.248+0800 [INFO]  Failed to read plugin lock file .terraform/plugins/darwin_amd64/lock.json: open .terraform/plugins/darwin_amd64/lock.json: no such file or directory
2021-08-13T15:50:23.249+0800 [INFO]  backend/local: starting Apply operation
2021-08-13T15:50:23.250+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:50:23.708+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:50:23.708+0800
2021-08-13T15:50:23.787+0800 [INFO]  terraform: building graph: GraphTypeValidate
2021-08-13T15:50:23.788+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:50:23.834+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:50:23.834+0800
2021-08-13T15:50:23.910+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:23 [WARN] Truncating attribute path of 0 diagnostics for TypeSet: timestamp=2021-08-13T15:50:23.910+0800
2021-08-13T15:50:23.913+0800 [INFO]  backend/local: apply calling Plan
2021-08-13T15:50:23.913+0800 [INFO]  terraform: building graph: GraphTypePlan
2021-08-13T15:50:23.914+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:50:23.963+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:50:23.963+0800
2021-08-13T15:50:24.037+0800 [WARN]  ValidateProviderConfig from "provider[\"registry.terraform.io/civo/civo\"]" changed the config value, but that value is unused
2021-08-13T15:50:24.038+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet: timestamp=2021-08-13T15:50:24.038+0800
2021-08-13T15:50:24.040+0800 [WARN]  Provider "registry.terraform.io/civo/civo" produced an invalid plan for civo_instance.my-test-instance, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .public_ip_required: planned value cty.StringVal("create") for a non-computed attribute
      - .size: planned value cty.StringVal("g3.xsmall") for a non-computed attribute
      - .initial_user: planned value cty.StringVal("civo") for a non-computed attribute

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # civo_instance.my-test-instance will be created
  + resource "civo_instance" "my-test-instance" {
      + cpu_cores          = (known after apply)
      + created_at         = (known after apply)
      + disk_gb            = (known after apply)
      + firewall_id        = (known after apply)
      + hostname           = "kubeform-test"
      + id                 = (known after apply)
      + initial_password   = (sensitive value)
      + initial_user       = "civo"
      + network_id         = (known after apply)
      + notes              = "this is a note for the server"
      + private_ip         = (known after apply)
      + pseudo_ip          = (known after apply)
      + public_ip          = (known after apply)
      + public_ip_required = "create"
      + ram_mb             = (known after apply)
      + size               = "g3.xsmall"
      + source_id          = (known after apply)
      + source_type        = (known after apply)
      + status             = (known after apply)
      + tags               = [
          + "nginx",
          + "python",
        ]
      + template           = "8eb48e20-e5db-49fe-9cdf-cc8f381c61c6"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
2021-08-13T15:50:24.043+0800 [INFO]  backend/local: apply calling Apply
2021-08-13T15:50:24.043+0800 [INFO]  terraform: building graph: GraphTypeApply
2021-08-13T15:50:24.044+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:50:24.091+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:50:24.091+0800
2021-08-13T15:50:24.164+0800 [WARN]  ValidateProviderConfig from "provider[\"registry.terraform.io/civo/civo\"]" changed the config value, but that value is unused
2021-08-13T15:50:24.165+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:24 [WARN] Truncating attribute path of 0 diagnostics for TypeSet: timestamp=2021-08-13T15:50:24.165+0800
2021-08-13T15:50:24.166+0800 [WARN]  Provider "registry.terraform.io/civo/civo" produced an invalid plan for civo_instance.my-test-instance, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .size: planned value cty.StringVal("g3.xsmall") for a non-computed attribute
      - .initial_user: planned value cty.StringVal("civo") for a non-computed attribute
      - .public_ip_required: planned value cty.StringVal("create") for a non-computed attribute
civo_instance.my-test-instance: Creating...
2021-08-13T15:50:24.166+0800 [INFO]  Starting apply for civo_instance.my-test-instance
2021-08-13T15:50:24.167+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:24 [INFO] configuring the instance kubeform-test: timestamp=2021-08-13T15:50:24.167+0800
civo_instance.my-test-instance: Still creating... [10s elapsed]
civo_instance.my-test-instance: Still creating... [20s elapsed]
2021-08-13T15:50:46.605+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:46 [INFO] creating the instance kubeform-test: timestamp=2021-08-13T15:50:46.604+0800
2021-08-13T15:50:50.183+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:50 [DEBUG] Waiting for state to become: [ACTIVE]: timestamp=2021-08-13T15:50:50.183+0800
civo_instance.my-test-instance: Still creating... [30s elapsed]
2021-08-13T15:50:54.935+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:54 [TRACE] Waiting 3s before next try: timestamp=2021-08-13T15:50:54.935+0800
2021-08-13T15:50:59.513+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:50:59 [TRACE] Waiting 6s before next try: timestamp=2021-08-13T15:50:59.513+0800
civo_instance.my-test-instance: Still creating... [40s elapsed]
2021-08-13T15:51:07.181+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:51:07 [TRACE] Waiting 10s before next try: timestamp=2021-08-13T15:51:07.181+0800
civo_instance.my-test-instance: Still creating... [50s elapsed]
2021-08-13T15:51:18.958+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:51:18 [TRACE] Waiting 10s before next try: timestamp=2021-08-13T15:51:18.958+0800
civo_instance.my-test-instance: Still creating... [1m0s elapsed]
civo_instance.my-test-instance: Still creating... [1m10s elapsed]
2021-08-13T15:51:35.062+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:51:35 [INFO] retriving the instance ee5e2f27-a4d7-4fcd-951a-49ed797a65ef: timestamp=2021-08-13T15:51:35.061+0800
2021-08-13T15:51:36.777+0800 [WARN]  Provider "provider[\"registry.terraform.io/civo/civo\"]" produced an unexpected new value for civo_instance.my-test-instance, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .script: was null, but now cty.StringVal("")
      - .reverse_dns: was null, but now cty.StringVal("")
      - .sshkey_id: was null, but now cty.StringVal("")
civo_instance.my-test-instance: Creation complete after 1m13s [id=ee5e2f27-a4d7-4fcd-951a-49ed797a65ef]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 
~/civo/test-civo-terraform-provider ᐅ civo instance show kubeform-test
              ID : ee5e2f27-a4d7-4fcd-951a-49ed797a65ef
        Hostname : kubeform-test
          Status : ACTIVE
            Size : g3.xsmall
       Cpu Cores : 1
             Ram : 1024
        SSD disk : 25
          Region : NYC1
      Network ID : fb3cdfff-66ba-4048-9f37-8625237cbe67
     Template ID :
     Snapshot ID :
    Initial User : civo
Initial Password : civo
         SSH Key :
     Firewall ID : c1ce01cf-5e01-4378-8f03-f93a45d31843
            Tags : python nginx
      Created At : Mon, 01 Jan 0001 00:00:00 UTC
      Private IP : 192.168.1.7
       Public IP : 212.2.246.204

---------------------------------- Notes ----------------------------------
this is a note for the server
 
~/civo/test-civo-terraform-provider ᐅ nano main.tf
 
~/civo/test-civo-terraform-provider ᐅ cat main.tf
resource "civo_instance" "my-test-instance" {
    hostname = "kubeform-test"
    tags = ["python", "nginx"]
    notes = "this is a note for the server"
    size = "g3.large"
    template = "8eb48e20-e5db-49fe-9cdf-cc8f381c61c6"
}
 
~/civo/test-civo-terraform-provider ᐅ tf apply --auto-approve
2021-08-13T15:52:34.781+0800 [INFO]  Terraform version: 1.0.3
2021-08-13T15:52:34.781+0800 [INFO]  Go runtime version: go1.16.4
2021-08-13T15:52:34.781+0800 [INFO]  CLI args: []string{"/usr/local/bin/terraform", "apply", "--auto-approve"}
2021-08-13T15:52:34.781+0800 [INFO]  Loading CLI configuration from /Users/zulh/.terraformrc
2021-08-13T15:52:34.781+0800 [INFO]  CLI command args: []string{"apply", "--auto-approve"}
2021-08-13T15:52:34.859+0800 [INFO]  Failed to read plugin lock file .terraform/plugins/darwin_amd64/lock.json: open .terraform/plugins/darwin_amd64/lock.json: no such file or directory
2021-08-13T15:52:34.859+0800 [INFO]  backend/local: starting Apply operation
2021-08-13T15:52:34.862+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:52:34.912+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:52:34.912+0800
2021-08-13T15:52:34.988+0800 [INFO]  terraform: building graph: GraphTypeValidate
2021-08-13T15:52:34.989+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:52:35.036+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:52:35.035+0800
2021-08-13T15:52:35.109+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:35 [WARN] Truncating attribute path of 0 diagnostics for TypeSet: timestamp=2021-08-13T15:52:35.109+0800
2021-08-13T15:52:35.112+0800 [INFO]  backend/local: apply calling Plan
2021-08-13T15:52:35.112+0800 [INFO]  terraform: building graph: GraphTypePlan
2021-08-13T15:52:35.113+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:52:35.160+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:52:35.160+0800
2021-08-13T15:52:35.235+0800 [WARN]  ValidateProviderConfig from "provider[\"registry.terraform.io/civo/civo\"]" changed the config value, but that value is unused
civo_instance.my-test-instance: Refreshing state... [id=ee5e2f27-a4d7-4fcd-951a-49ed797a65ef]
2021-08-13T15:52:35.238+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:35 [INFO] retriving the instance ee5e2f27-a4d7-4fcd-951a-49ed797a65ef: timestamp=2021-08-13T15:52:35.238+0800
2021-08-13T15:52:37.606+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:37 [WARN] Truncating attribute path of 0 diagnostics for TypeSet: timestamp=2021-08-13T15:52:37.606+0800
2021-08-13T15:52:37.610+0800 [WARN]  Provider "registry.terraform.io/civo/civo" produced an invalid plan for civo_instance.my-test-instance, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .public_ip_required: planned value cty.StringVal("create") for a non-computed attribute
      - .initial_user: planned value cty.StringVal("civo") for a non-computed attribute
      - .reverse_dns: planned value cty.StringVal("") for a non-computed attribute
      - .script: planned value cty.StringVal("") for a non-computed attribute
      - .sshkey_id: planned value cty.StringVal("") for a non-computed attribute

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # civo_instance.my-test-instance will be updated in-place
  ~ resource "civo_instance" "my-test-instance" {
        id                 = "ee5e2f27-a4d7-4fcd-951a-49ed797a65ef"
      ~ size               = "g3.xsmall" -> "g3.large"
        tags               = [
            "nginx",
            "python",
        ]
        # (17 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
2021-08-13T15:52:37.618+0800 [INFO]  backend/local: apply calling Apply
2021-08-13T15:52:37.618+0800 [INFO]  terraform: building graph: GraphTypeApply
2021-08-13T15:52:37.619+0800 [INFO]  provider: configuring client automatic mTLS
2021-08-13T15:52:37.673+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: configuring server automatic mTLS: timestamp=2021-08-13T15:52:37.673+0800
2021-08-13T15:52:37.746+0800 [WARN]  ValidateProviderConfig from "provider[\"registry.terraform.io/civo/civo\"]" changed the config value, but that value is unused
2021-08-13T15:52:37.750+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:37 [WARN] Truncating attribute path of 0 diagnostics for TypeSet: timestamp=2021-08-13T15:52:37.750+0800
2021-08-13T15:52:37.751+0800 [WARN]  Provider "registry.terraform.io/civo/civo" produced an invalid plan for civo_instance.my-test-instance, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .sshkey_id: planned value cty.StringVal("") for a non-computed attribute
      - .public_ip_required: planned value cty.StringVal("create") for a non-computed attribute
      - .initial_user: planned value cty.StringVal("civo") for a non-computed attribute
      - .reverse_dns: planned value cty.StringVal("") for a non-computed attribute
      - .script: planned value cty.StringVal("") for a non-computed attribute
civo_instance.my-test-instance: Modifying... [id=ee5e2f27-a4d7-4fcd-951a-49ed797a65ef]
2021-08-13T15:52:37.752+0800 [INFO]  Starting apply for civo_instance.my-test-instance
2021-08-13T15:52:37.753+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:37 [INFO] resizing the instance ee5e2f27-a4d7-4fcd-951a-49ed797a65ef: timestamp=2021-08-13T15:52:37.753+0800
2021-08-13T15:52:40.485+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:40 [DEBUG] Waiting for state to become: [success]: timestamp=2021-08-13T15:52:40.485+0800
2021-08-13T15:52:42.108+0800 [INFO]  provider.terraform-provider-civo_v99.0.0: 2021/08/13 15:52:42 [INFO] retriving the instance ee5e2f27-a4d7-4fcd-951a-49ed797a65ef: timestamp=2021-08-13T15:52:42.108+0800
2021-08-13T15:52:43.764+0800 [WARN]  Provider "provider[\"registry.terraform.io/civo/civo\"]" produced an unexpected new value for civo_instance.my-test-instance, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .disk_gb: was cty.NumberIntVal(25), but now cty.NumberIntVal(100)
      - .cpu_cores: was cty.NumberIntVal(1), but now cty.NumberIntVal(4)
      - .ram_mb: was cty.NumberIntVal(1024), but now cty.NumberIntVal(8192)
civo_instance.my-test-instance: Modifications complete after 6s [id=ee5e2f27-a4d7-4fcd-951a-49ed797a65ef]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
 
~/civo/test-civo-terraform-provider ᐅ civo instance show kubeform-test
              ID : ee5e2f27-a4d7-4fcd-951a-49ed797a65ef
        Hostname : kubeform-test
          Status : ACTIVE
            Size : g3.large
       Cpu Cores : 4
             Ram : 8192
        SSD disk : 100
          Region : NYC1
      Network ID : fb3cdfff-66ba-4048-9f37-8625237cbe67
     Template ID :
     Snapshot ID :
    Initial User : civo
Initial Password : civo
         SSH Key :
     Firewall ID : c1ce01cf-5e01-4378-8f03-f93a45d31843
            Tags : python nginx
      Created At : Mon, 01 Jan 0001 00:00:00 UTC
      Private IP : 192.168.1.7
       Public IP : 212.2.246.204

---------------------------------- Notes ----------------------------------
this is a note for the server
  ```
</details>