### PR TITLE
Fix cluster primary nodepool scaling bug

### DIFF
--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 // Kubernetes Cluster resource, with this you can manage all cluster from terraform
@@ -41,7 +42,7 @@ func resourceKubernetesCluster() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				Description:  "the number of instances to create (optional, the default at the time of writing is 3)",
-				ValidateFunc: utils.ValidateNumTargetNodes,
+				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"target_nodes_size": {
 				Type:        schema.TypeString,

--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -37,10 +37,11 @@ func resourceKubernetesCluster() *schema.Resource {
 				Description: "The network for the cluster, if not declare we use the default one",
 			},
 			"num_target_nodes": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
-				Description: "the number of instances to create (optional, the default at the time of writing is 3)",
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				Description:  "the number of instances to create (optional, the default at the time of writing is 3)",
+				ValidateFunc: utils.ValidateNumTargetNodes,
 			},
 			"target_nodes_size": {
 				Type:        schema.TypeString,
@@ -377,8 +378,26 @@ func resourceKubernetesClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if d.HasChange("num_target_nodes") {
-		config.NumTargetNodes = d.Get("num_target_nodes").(int)
+		numTargetNodes := d.Get("num_target_nodes").(int)
+
 		config.Region = apiClient.Region
+		kubernetesCluster, err := apiClient.FindKubernetesCluster(d.Id())
+		if err != nil {
+			return err
+		}
+
+		targetNodePool := ""
+		nodePools := []civogo.KubernetesClusterPoolConfig{}
+		for _, v := range kubernetesCluster.Pools {
+			nodePools = append(nodePools, civogo.KubernetesClusterPoolConfig{ID: v.ID, Count: v.Count, Size: v.Size})
+
+			if targetNodePool == "" && v.Size == d.Get("target_nodes_size").(string) {
+				targetNodePool = v.ID
+			}
+		}
+
+		nodePools = updateNodePool(nodePools, targetNodePool, numTargetNodes)
+		config.Pools = nodePools
 	}
 
 	if d.HasChange("kubernetes_version") {
@@ -401,6 +420,7 @@ func resourceKubernetesClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	log.Printf("[INFO] updating the kubernetes cluster %s", d.Id())
+	log.Printf("[DEBUG] KubernetesClusterConfig: %+v\n", config)
 	_, err := apiClient.UpdateKubernetesCluster(d.Id(), config)
 	if err != nil {
 		return fmt.Errorf("[ERR] failed to update kubernetes cluster: %s", err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -49,6 +49,16 @@ func ValidateNameSize(v interface{}, k string) (ws []string, es []error) {
 	return warns, errs
 }
 
+func ValidateNumTargetNodes(value interface{}, key string) (warns []string, errs []error) {
+	v := value.(int)
+	if v <= 0 {
+		errs = append(errs, fmt.Errorf("%q cannot be zero or negative, got: %d", key, v))
+		return warns, errs
+	}
+
+	return
+}
+
 // util function to help the import function
 func ResourceCommonParseID(id string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -49,16 +49,6 @@ func ValidateNameSize(v interface{}, k string) (ws []string, es []error) {
 	return warns, errs
 }
 
-func ValidateNumTargetNodes(value interface{}, key string) (warns []string, errs []error) {
-	v := value.(int)
-	if v <= 0 {
-		errs = append(errs, fmt.Errorf("%q cannot be zero or negative, got: %d", key, v))
-		return warns, errs
-	}
-
-	return
-}
-
 // util function to help the import function
 func ResourceCommonParseID(id string) (string, string, error) {
 	parts := strings.SplitN(id, ":", 2)


### PR DESCRIPTION
Closes #52 

Also added a validation for `num_target_nodes` field. Only positive number should be accepted moving forward.

Example error when user provide `0` or negative number:

<img width="602" alt="Screenshot 2021-08-17 at 10 19 48 AM" src="https://user-images.githubusercontent.com/75463191/129659043-2853b2a1-c5b7-4cda-8f8d-fb60b3fe560c.png">
