### PR TITLE
Add firewall support for Kubernetes cluster

### DIFF
--- a/civo/resource_firewall_rule.go
+++ b/civo/resource_firewall_rule.go
@@ -194,7 +194,7 @@ func resourceFirewallRuleDelete(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[INFO] retriving the firewall rule %s", d.Id())
 	_, err := apiClient.DeleteFirewallRule(d.Get("firewall_id").(string), d.Id())
 	if err != nil {
-		return fmt.Errorf("[ERR] an error occurred while tring to delete firewall rule %s", d.Id())
+		return fmt.Errorf("[ERR] an error occurred while tring to delete firewall rule %s - %v", d.Id(), err)
 	}
 	return nil
 }

--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -70,6 +70,11 @@ func resourceKubernetesCluster() *schema.Resource {
 					"'civo kubernetes applications ls'." +
 					"If you want to remove a default installed application, prefix it with a '-', e.g. -Traefik.",
 			},
+			"firewall_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The existing firewall ID to use for this cluster",
+			},
 			// Computed resource
 			"instances":              instanceSchema(),
 			"installed_applications": applicationSchema(),
@@ -275,6 +280,10 @@ func resourceKubernetesClusterCreate(d *schema.ResourceData, m interface{}) erro
 		}
 	} else {
 		config.Applications = ""
+	}
+
+	if attr, ok := d.GetOk("firewall_id"); ok {
+		config.InstanceFirewall = attr.(string)
 	}
 
 	log.Printf("[INFO] creating a new kubernetes cluster %s", d.Get("name").(string))

--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -283,7 +283,17 @@ func resourceKubernetesClusterCreate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if attr, ok := d.GetOk("firewall_id"); ok {
-		config.InstanceFirewall = attr.(string)
+		firewallID := attr.(string)
+		firewall, err := apiClient.FindFirewall(firewallID)
+		if err != nil {
+			return fmt.Errorf("[ERR] unable to find firewall - %s", err)
+		}
+
+		if firewall.NetworkID != config.NetworkID {
+			return fmt.Errorf("[ERR] firewall %s is not part of network %s", firewall.ID, config.NetworkID)
+		}
+
+		config.InstanceFirewall = firewallID
 	}
 
 	log.Printf("[INFO] creating a new kubernetes cluster %s", d.Get("name").(string))
@@ -353,6 +363,7 @@ func resourceKubernetesClusterRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("dns_entry", resp.DNSEntry)
 	// d.Set("built_at", resp.BuiltAt.UTC().String())
 	d.Set("created_at", resp.CreatedAt.UTC().String())
+	d.Set("firewall_id", resp.FirewallID)
 
 	if err := d.Set("instances", flattenInstances(resp.Instances)); err != nil {
 		return fmt.Errorf("[ERR] error retrieving the instances for kubernetes cluster error: %#v", err)
@@ -379,6 +390,14 @@ func resourceKubernetesClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	config := &civogo.KubernetesClusterConfig{}
+
+	if d.HasChange("network_id") {
+		return fmt.Errorf("[ERR] Network change (%q) for existing cluster is not available at this moment", "network_id")
+	}
+
+	if d.HasChange("firewall_id") {
+		return fmt.Errorf("[ERR] Firewall change (%q) for existing cluster is not available at this moment", "firewall_id")
+	}
 
 	if d.HasChange("target_nodes_size") {
 		errMsg := []string{

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/civo/terraform-provider-civo
 
 require (
 	github.com/aws/aws-sdk-go v1.29.22 // indirect
-	github.com/civo/civogo v0.2.49
+	github.com/civo/civogo v0.2.52
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/civo/civogo v0.2.49 h1:tLIzbUIh3Za3Xc+dwR6IUrP1eF66P7N91kIe0S/jDhw=
 github.com/civo/civogo v0.2.49/go.mod h1:SR0ZOhABfQHjgNQE3UyfX4gaYsrfslkPFRFMx5P29rg=
+github.com/civo/civogo v0.2.52 h1:oeMmeGuJOZFJ+uruu13ywCWOxSa2+Lyk+ePc6rxC8gY=
+github.com/civo/civogo v0.2.52/go.mod h1:SR0ZOhABfQHjgNQE3UyfX4gaYsrfslkPFRFMx5P29rg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Depends on https://github.com/civo/civogo/pull/60. Close #35.

---

Example configuration file:

```terraform
resource "civo_network" "my_custom_network" {
  label  = "my-custom-network"
}

resource "civo_firewall" "my_custom_firewall" {
  name       = "my-custom-firewall"
  network_id = civo_network.my_custom_network.id
}

resource "civo_firewall_rule" "http" {
  firewall_id = civo_firewall.my_custom_firewall.id
  protocol    = "tcp"
  start_port  = "80"
  end_port    = "80"
  direction   = "ingress"
  label       = "web-server"
  depends_on  = [civo_firewall.my_custom_firewall]
}

resource "civo_kubernetes_cluster" "my_cluster" {
  name              = "my_cluster"
  num_target_nodes  = 1
  target_nodes_size = "g3.k3s.medium"
  network_id        = civo_network.my_custom_network.id
  firewall_id       = civo_firewall.my_custom_firewall.id
}
```