### PR TITLE
Disable k8s version upgrade

### DIFF
--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -432,8 +432,9 @@ func resourceKubernetesClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if d.HasChange("kubernetes_version") {
-		config.KubernetesVersion = d.Get("kubernetes_version").(string)
-		config.Region = apiClient.Region
+		// config.KubernetesVersion = d.Get("kubernetes_version").(string)
+		// config.Region = apiClient.Region
+		return fmt.Errorf("[ERR] Kubernetes version upgrade (%q attribute) is not supported yet", "kubernetes_version")
 	}
 
 	if d.HasChange("applications") {
@@ -442,7 +443,7 @@ func resourceKubernetesClusterUpdate(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if d.HasChange("name") {
-		config.Applications = d.Get("name").(string)
+		config.Name = d.Get("name").(string)
 		config.Region = apiClient.Region
 	}
 


### PR DESCRIPTION
- Close #95
- Close #97 

When user tries to upgrade their cluster's Kubernetes version, they will get this:

![Screenshot from 2021-09-22 12-30-37](https://user-images.githubusercontent.com/75463191/134284702-2058a5a4-9011-46ca-ac84-8781ccd69d7b.png)
