### PR TITLE
GitHub Actions - Auto generate changelog and docs when publish a new release

### DIFF
--- a/.auto-changelog-config
+++ b/.auto-changelog-config
@@ -1,0 +1,5 @@
+{
+    "template": ".auto-changelog-template.hbs",
+    "commitLimit": 100,
+    "ignoreCommitPattern": "Update docs and CHANGELOG.md"
+}

--- a/.auto-changelog-template.hbs
+++ b/.auto-changelog-template.hbs
@@ -1,0 +1,18 @@
+{{#each releases}}
+  
+  ## [{{title}}](https://github.com/civo/terraform-provider-civo/releases/tag/{{title}}) ({{niceDate}})
+  
+  {{#if merges}}
+    ### Merged
+    {{#each merges}}
+        - [#{{id}}]({{href}}) - {{message}}
+    {{/each}}
+  {{/if}}
+  
+  {{#if commits}}
+    ### Commits
+    {{#each commits}}
+        - [{{shorthash}}]({{href}}) - {{subject}}
+    {{/each}}
+  {{/if}}
+{{/each}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,67 @@
-name: goreleaser
+name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      newVersionTag:
+        description: 'New version tag (e.g. v0.10.11)'     
+        required: true
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v2
-      -
-        name: Unshallow
+
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Set up Go
+      
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
-      - 
-        name: Import GPG key
+
+      - name: Install and run tfplugindocs CLI
+        run: |
+          mkdir downloads
+          cd downloads
+          wget https://github.com/hashicorp/terraform-plugin-docs/releases/download/v0.5.0/tfplugindocs_0.5.0_linux_amd64.zip
+          unzip tfplugindocs_0.5.0_linux_amd64.zip
+          cd ..
+          mv downloads/tfplugindocs .
+          ./tfplugindocs generate
+          rm -rf ./tfplugindocs downloads
+      
+      - name: Install and run auto-changelog CLI
+        run: |
+          npm i -g auto-changelog@2.3.0
+          auto-changelog --config=.auto-changelog-config --latest-version=${{ github.event.inputs.newVersionTag }}
+      
+      - name: Setup Git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "<>"
+
+      - name: Add and commit generated files
+        run: |
+          git add .
+          git commit -m "Update docs and CHANGELOG.md"
+
+      - name: Create a tag and push
+        run: |
+          git pull origin master
+          git tag -a ${{ github.event.inputs.newVersionTag }} -m ""
+          git push origin master --follow-tags
+      
+      - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      -
-        name: Run GoReleaser
+      
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           args: release --rm-dist


### PR DESCRIPTION
Tho trigger this _release_ workflow moving forward, we can use GitHub web UI or [GitHub CLI v2](https://cli.github.com/):

### GitHub web UI

![image](https://user-images.githubusercontent.com/75463191/134868027-c9f94fb9-fdf7-4e01-b769-365fe861f6ca.png)

- Go to Actions > Release > Run workflow
- Enter the new version to release e.g. `v0.10.11`
- Click the `Run workflow` button

### GitHub CLI

Run:

```
$ gh workflow run release.yml --repo civo/terraform-provider-civo --field newVersionTag=vX.X.X
```

Example:

```
$ gh workflow run release.yml --repo civo/terraform-provider-civo --field newVersionTag=v0.10.11
```

References:

- https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
- https://cli.github.com/manual/gh_workflow_run