### PR TITLE
Add missing required provider section in terraform docs provider example

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 # Set the variable value in *.tfvars file or using -var="civo_token=..." CLI flag
 variable "civo_token" {}
 
-# Specify required provider
+# Specify required provider as maintained by civo
 terraform {
   required_providers {
     civo = {


### PR DESCRIPTION
The current example omits the required terraform block specifying the provider required. As this Civo provider is maintained by Civo and not Hasicorp, the absence of this configuration causes the `terraform init` to fail. 

This pull request adds this extra bit of configuration to the example.