### PR TITLE
Remove newly added id attributes in resources

### DIFF
--- a/civo/resource_dns_domain_name.go
+++ b/civo/resource_dns_domain_name.go
@@ -21,11 +21,6 @@ func resourceDNSDomainName() *schema.Resource {
 				ValidateFunc: utils.ValidateName,
 			},
 			// Computed resource
-			"id": {
-				Description: "The ID of this resource.",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
 			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/civo/resource_dns_domain_record.go
+++ b/civo/resource_dns_domain_record.go
@@ -57,11 +57,6 @@ func resourceDNSDomainRecord() *schema.Resource {
 				Description:  "How long caching DNS servers should cache this record for, in seconds (the minimum is 600 and the default if unspecified is 600)",
 			},
 			// Computed resource
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource.",
-			},
 			"account_id": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/civo/resource_firewall.go
+++ b/civo/resource_firewall.go
@@ -31,12 +31,6 @@ func resourceFirewall() *schema.Resource {
 				Computed:    true,
 				Description: "The firewall network, if is not defined we use the default network",
 			},
-			// Computed resource
-			"id": {
-				Description: "The ID of this resource.",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
 		},
 		Create: resourceFirewallCreate,
 		Read:   resourceFirewallRead,

--- a/civo/resource_firewall_rule.go
+++ b/civo/resource_firewall_rule.go
@@ -85,12 +85,6 @@ func resourceFirewallRule() *schema.Resource {
 				Description:  "The region for this rule",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
-			// Computed resource
-			"id": {
-				Description: "The ID of this resource.",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
 		},
 		Create: resourceFirewallRuleCreate,
 		Read:   resourceFirewallRuleRead,

--- a/civo/resource_instance.go
+++ b/civo/resource_instance.go
@@ -108,11 +108,6 @@ func resourceInstance() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			// Computed resource
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource.",
-			},
 			"cpu_cores": {
 				Type:        schema.TypeInt,
 				Computed:    true,

--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -80,11 +80,6 @@ func resourceKubernetesCluster() *schema.Resource {
 				Description: "The existing firewall ID to use for this cluster",
 			},
 			// Computed resource
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource.",
-			},
 			"instances":              instanceSchema(),
 			"installed_applications": applicationSchema(),
 			"pools":                  nodePoolSchema(),
@@ -190,11 +185,6 @@ func nodePoolSchema() *schema.Schema {
 		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"id": {
-					Type:        schema.TypeString,
-					Computed:    true,
-					Description: "Nodepool ID",
-				},
 				"count": {
 					Type:        schema.TypeInt,
 					Computed:    true,

--- a/civo/resource_kubernetes_cluster_nodepool.go
+++ b/civo/resource_kubernetes_cluster_nodepool.go
@@ -46,11 +46,6 @@ func resourceKubernetesClusterNodePool() *schema.Resource {
 				Computed:    true,
 				Description: "the size of each node (optional, the default is currently g3.k3s.medium)",
 			},
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource.",
-			},
 		},
 		Create: resourceKubernetesClusterNodePoolCreate,
 		Read:   resourceKubernetesClusterNodePoolRead,

--- a/civo/resource_network.go
+++ b/civo/resource_network.go
@@ -36,11 +36,6 @@ func resourceNetwork() *schema.Resource {
 				Computed:    true,
 				Description: "If the network is default, this will be `true`",
 			},
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource",
-			},
 		},
 		Create: resourceNetworkCreate,
 		Read:   resourceNetworkRead,

--- a/civo/resource_ssh.go
+++ b/civo/resource_ssh.go
@@ -32,11 +32,6 @@ func resourceSSHKey() *schema.Resource {
 				Computed:    true,
 				Description: "a string containing the SSH finger print.",
 			},
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource.",
-			},
 		},
 		Create: resourceSSHKeyCreate,
 		Read:   resourceSSHKeyRead,

--- a/civo/resource_volume_attachment.go
+++ b/civo/resource_volume_attachment.go
@@ -36,12 +36,6 @@ func resourceVolumeAttachment() *schema.Resource {
 				ForceNew:    true,
 				Description: "The region for the volume attachment",
 			},
-			// Computed resource
-			"id": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "The ID of this resource.",
-			},
 		},
 		Create: resourceVolumeAttachmentCreate,
 		Read:   resourceVolumeAttachmentRead,


### PR DESCRIPTION
As part of #92, new "id" attributes were added to the schema for some
of the resources. These are not actually needed since they are part of
the plugin sdk by default. These parameters were not required before
and "id" is something that is available on *ALL* TF based resources

Because we (Pulumi) dervice our schema from your schema (and the plugin SDK)
we are getting the following error:

```
sdk/python/bin/build/lib/pulumi_civo/dns_domain_name.py:218: error: Duplicate argument "id" in function definition
```

If the schema needed these, then the make build would fail but it still works

```
▶ make build
==> Checking that code complies with gofmt requirements...
go install
```

You can see from the internals of the plugin SDK (helper/schema/resource_data.go),
the following func:

```
// SetId sets the ID of the resource. If the value is blank, then the
// resource is destroyed.
func (d *ResourceData) SetId(v string) {
	d.once.Do(d.init)
	d.newState.ID = v

	// once we transition away from the legacy state types, "id" will no longer
	// be a special field, and will become a normal attribute.
	// set the attribute normally
	d.setWriter.unsafeWriteField("id", v)

	// Make sure the newState is also set, otherwise the old value
	// may get precedence.
	if d.newState.Attributes == nil {
		d.newState.Attributes = map[string]string{}
	}
	d.newState.Attributes["id"] = v
}
```

So when you use d.SetID, it actually creates the ID attribute for you
