### PR TITLE
`node_pool` resource does not accept `id` as a parameter

### DIFF
--- a/docs/resources/kubernetes_node_pool.md
+++ b/docs/resources/kubernetes_node_pool.md
@@ -51,7 +51,6 @@ resource "civo_kubernetes_node_pool" "front-end" {
 
 ### Optional
 
-- **id** (String) The ID of this resource.
 - **num_target_nodes** (Number) the number of instances to create (optional, the default at the time of writing is 3)
 - **target_nodes_size** (String) the size of each node (optional, the default is currently g3.k3s.medium)
 


### PR DESCRIPTION
`id` is not in the schema of the `node_pool` resource, and
an error occurs if you try to set it:

```
Error: Invalid or unknown key

  on cluster.tf line 31, in resource "civo_kubernetes_node_pool" "my":
  31:   id                = "my-id"
```