### PR TITLE
Replace the firewall if network id changes

### DIFF
--- a/civo/resource_firewall.go
+++ b/civo/resource_firewall.go
@@ -25,10 +25,13 @@ func resourceFirewall() *schema.Resource {
 				Optional:    true,
 				Description: "The firewall region, if is not defined we use the global defined in the provider",
 			},
+			// As the backend has no support for updating network ID we replace it if the
+			// network_id changes
 			"network_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: "The firewall network, if is not defined we use the default network",
 			},
 		},


### PR DESCRIPTION
As there doesn't appear to be a documented way to update `network_id`,
replace the firewall if the network id changes