### PR TITLE
Add Data source for `civo_firewall`

### DIFF
--- a/civo/datasource_firewall.go
+++ b/civo/datasource_firewall.go
@@ -1,0 +1,87 @@
+package civo
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/civo/civogo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// Data source to get from the api a specific firewall
+// using the id or the label
+func dataSourceFirewall() *schema.Resource {
+	return &schema.Resource{
+		Description: strings.Join([]string{
+			"Retrieve information about a firewall for use in other resources.",
+			"This data source provides all of the firewall's properties as configured on your Civo account.",
+			"Firewalls may be looked up by id or label, and you can optionally pass region if you want to make a lookup for an expecific firewall inside that region.",
+		}, "\n\n"),
+		Read: dataSourceFirewallRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.NoZeroValues,
+				ExactlyOneOf: []string{"id", "name"},
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.NoZeroValues,
+				ExactlyOneOf: []string{"id", "name"},
+				Description:  "The name of the Kubernetes Cluster",
+			},
+			"region": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.NoZeroValues,
+				Description:  "The region where cluster is running",
+			},
+			// Computed resource
+			"network_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The id of the associated network",
+			},
+		},
+	}
+}
+
+func dataSourceFirewallRead(d *schema.ResourceData, m interface{}) error {
+	apiClient := m.(*civogo.Client)
+
+	// overwrite the region if is define in the datasource
+	if region, ok := d.GetOk("region"); ok {
+		apiClient.Region = region.(string)
+	}
+
+	var foundFirewall *civogo.Firewall
+
+	if id, ok := d.GetOk("id"); ok {
+		log.Printf("[INFO] Getting the firewall by id")
+		firewall, err := apiClient.FindFirewall(id.(string))
+		if err != nil {
+			return fmt.Errorf("[ERR] failed to retrive firewall: %s", err)
+		}
+
+		foundFirewall = firewall
+	} else if name, ok := d.GetOk("name"); ok {
+		log.Printf("[INFO] Getting the firewall by name")
+		firewall, err := apiClient.FindFirewall(name.(string))
+		if err != nil {
+			return fmt.Errorf("[ERR] failed to retrive firewall: %s", err)
+		}
+
+		foundFirewall = firewall
+	}
+
+	d.SetId(foundFirewall.ID)
+	d.Set("name", foundFirewall.Name)
+	d.Set("network_id", foundFirewall.NetworkID)
+	d.Set("region", apiClient.Region)
+
+	return nil
+}

--- a/civo/datasource_firewall_test.go
+++ b/civo/datasource_firewall_test.go
@@ -1,0 +1,39 @@
+package civo
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceCivoFirewall_basic(t *testing.T) {
+	datasourceName := "data.civo_firewall.foobar"
+	name := acctest.RandomWithPrefix("net-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCivoFirewallConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCivoFirewallConfig(name string) string {
+	return fmt.Sprintf(`
+resource "civo_firewall" "foobar" {
+	label = "%s"
+}
+
+data "civo_firewall" "foobar" {
+	label = civo_firewall.foobar.name
+}
+`, name)
+}

--- a/civo/provider.go
+++ b/civo/provider.go
@@ -40,6 +40,7 @@ func Provider() *schema.Provider {
 			"civo_dns_domain_record":  dataSourceDNSDomainRecord(),
 			"civo_network":            dataSourceNetwork(),
 			"civo_volume":             dataSourceVolume(),
+			"civo_firewall":           dataSourceFirewall(),
 			// "civo_loadbalancer":       dataSourceLoadBalancer(),
 			"civo_ssh_key": dataSourceSSHKey(),
 			// "civo_snapshot":           dataSourceSnapshot(),


### PR DESCRIPTION
With this PR, we should be able to query firewall using datasource, for example,

```
data "civo_firewall" "myfirewall" {
  name = "myfirewall"
}
```