### PR TITLE
fix: remove double default

### DIFF
--- a/civo/provider.go
+++ b/civo/provider.go
@@ -23,7 +23,6 @@ func Provider() *schema.Provider {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     "",
 				DefaultFunc: schema.EnvDefaultFunc("CIVO_REGION", ""),
 				Description: "If region is not set, then no region will be used and them you need expensify in every resource even if you expensify here you can overwrite in a resource.",
 			},


### PR DESCRIPTION
I was wondering why my clusters with exported env var `CIVO_REGION="FRA1"` were created in `NYC1`. Removing the empty `Default` fixed the issue