### PR TITLE
`civo_firewall_rule` resource missing required argument action

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -40,6 +40,7 @@ resource "civo_firewall_rule" "kubernetes" {
     cidr = ["0.0.0.0/0"]
     direction = "ingress"
     label = "kubernetes-api-server"
+    action = "allow"
 }
 
 # Create a cluster

--- a/examples/resources/civo_kubernetes_cluster/resource.tf
+++ b/examples/resources/civo_kubernetes_cluster/resource.tf
@@ -25,6 +25,7 @@ resource "civo_firewall_rule" "kubernetes" {
     cidr = ["0.0.0.0/0"]
     direction = "ingress"
     label = "kubernetes-api-server"
+    action = "allow"
 }
 
 # Create a cluster


### PR DESCRIPTION
added missing required argument action in resource civo_firewall_rule

While executing tf plan:
```
╷
│ Error: Missing required argument
│ 
│   on cluster.tf line 16, in resource "civo_firewall_rule" "kubernetes":
│   16: resource "civo_firewall_rule" "kubernetes" {
│ 
│ The argument "action" is required, but
│ no definition was found.
```