### PR TITLE
[Fix-140]- `region` in `civo_kubernetes_node_pool` made optional

### DIFF
--- a/civo/resource_kubernetes_cluster_nodepool.go
+++ b/civo/resource_kubernetes_cluster_nodepool.go
@@ -36,8 +36,8 @@ func resourceKubernetesClusterNodePool() *schema.Resource {
 			},
 			"region": {
 				Type:         schema.TypeString,
-				Required:     true,
-				Description:  "The region of the node pool, has to match that of the cluster",
+				Required:     false,
+				Description:  "The region of the node pool, has to match that of the cluster. if not declare we use the region in declared in the provider",
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"num_target_nodes": {


### PR DESCRIPTION
Fixes: #140 The `region` key in `civo_kubernetes_node_pool`should be optional and should default to the region in provider definition if not specified