### PR TITLE
Add the UPGRADING state to the cluster creation

### DIFF
--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -297,7 +297,7 @@ func resourceKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData
 	d.SetId(resp.ID)
 
 	createStateConf := &resource.StateChangeConf{
-		Pending: []string{"BUILDING", "AVAILABLE"},
+		Pending: []string{"BUILDING", "AVAILABLE", "UPGRADING"},
 		Target:  []string{"ACTIVE"},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := apiClient.GetKubernetesCluster(d.Id())


### PR DESCRIPTION
This was reported by a user with this error:
```
│ Error: error waiting for cluster (UUID) to be created: unexpected state 'UPGRADING', wanted target 'ACTIVE'. last error: %!s(<nil>)
```