### PR TITLE
Fix: nil pointer check for instance

### DIFF
--- a/civo/datasource_instance.go
+++ b/civo/datasource_instance.go
@@ -155,7 +155,7 @@ func dataSourceInstanceRead(_ context.Context, d *schema.ResourceData, m interfa
 		log.Printf("[INFO] Getting the instance by id")
 		image, err := apiClient.FindInstance(id.(string))
 		if err != nil {
-			return diag.Errorf("[ERR] failed to retrive instance: %s", err)
+			return diag.Errorf("[ERR] failed to retrieve instance: %s", err)
 		}
 
 		foundImage = image
@@ -163,12 +163,15 @@ func dataSourceInstanceRead(_ context.Context, d *schema.ResourceData, m interfa
 		log.Printf("[INFO] Getting the instance by hostname")
 		image, err := apiClient.FindInstance(hostname.(string))
 		if err != nil {
-			return diag.Errorf("[ERR] failed to retrive instance: %s", err)
+			return diag.Errorf("[ERR] failed to retrieve instance: %s", err)
 		}
 
 		foundImage = image
 	}
-
+	//Check for nil pointer
+	if foundImage == nil {
+		return diag.Errorf("[ERR] failed to retrieve instance, image not found")
+	}
 	d.SetId(foundImage.ID)
 	d.Set("hostname", foundImage.Hostname)
 	d.Set("reverse_dns", foundImage.ReverseDNS)


### PR DESCRIPTION
**Problem:**
 - foundImage is Pointer of civogo.Instance
 - In case if GetOk() is not satisfied then both conditions will fail. foundImage  pointer will remain **nil**
 - If the pointer is nil then it will give a **memory access violation** for using foundImage.XXX properties.

**Solution:**
- If we are using pointer then need to check for nil value
- If nil value found then return error

**My Changes:**
 - Checking foundImage  pointer value is nil or not
 - if nil is found then return an error for dataSourceInstanceRead function
 - Spelling mistake correction:  retrive --> retrieve

