### PR TITLE
Remove spaces in the applications string

### DIFF
--- a/civo/resource_kubernetes_cluster.go
+++ b/civo/resource_kubernetes_cluster.go
@@ -274,7 +274,7 @@ func resourceKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData
 
 	if attr, ok := d.GetOk("applications"); ok {
 		if utils.CheckAPPName(attr.(string), apiClient) {
-			config.Applications = attr.(string)
+			config.Applications = strings.ReplaceAll(attr.(string), " ", "")
 		} else {
 			return diag.Errorf("[ERR] the app that tries to install is not valid: %s", attr.(string))
 		}


### PR DESCRIPTION
The list of applications needs to be supplied as comma-separated strings. 
Including spaces breaks the process.
This change should ensure no spaces are passed to the API.

In the current version, this example:
```
resource "civo_kubernetes_cluster" "civo001" {
  applications = "metrics-server, traefik2-nodeport, prometheus-operator"
  name         = "civo001"
  firewall_id  = civo_firewall.civo001.id
  cluster_type = "talos"
  pools {
    size       = "g4s.kube.medium"
    node_count = 3
  }
}
```
produces the following error:
`Error: [ERR] failed to create the kubernetes cluster: Error: Unknown error response - status: 404 Not Found, code: 404, reason: {"code":"database_kubernetes_aplication_not_found","reason":"Failed to find the Kubernetes application for installation"}`

Removing the spaces in the applications field takes care of the error.
