### PR TITLE
Destory and Re-create Instance in case of disk-image update

### DIFF
--- a/civo/instances/resource_instance.go
+++ b/civo/instances/resource_instance.go
@@ -71,10 +71,7 @@ func ResourceInstance() *schema.Resource {
 				Computed:     true,
 				ExactlyOneOf: []string{"template", "disk_image"},
 				Description:  "The ID for the disk image to use to build the instance",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					// Suppress changes if the old value is non-empty and different from the new value
-					return old != "" && old != new
-				},
+				ForceNew:     true,
 			},
 			"initial_user": {
 				Type:        schema.TypeString,

--- a/civo/instances/resource_instance.go
+++ b/civo/instances/resource_instance.go
@@ -71,6 +71,10 @@ func ResourceInstance() *schema.Resource {
 				Computed:     true,
 				ExactlyOneOf: []string{"template", "disk_image"},
 				Description:  "The ID for the disk image to use to build the instance",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress changes if the old value is non-empty and different from the new value
+					return old != "" && old != new
+				},
 			},
 			"initial_user": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
If user does any such change then we can do a destroy and create replacement. This would destroy the current present instance and create a new one. with the updated disk image.