### PR TITLE
Make CIDR immutable for network resource

### DIFF
--- a/civo/network/resource_network.go
+++ b/civo/network/resource_network.go
@@ -270,11 +270,12 @@ func expandStringList(input interface{}) []string {
 	return result
 }
 
-
 func customizeDiffNetwork(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	if d.Id() != "" && d.HasChange("cidr_v4") {
 		return fmt.Errorf("the 'cidr_v4' field is immutable")
 	}
+	return nil
+}
 
 // createDefaultFirewall function to create a default firewall
 func createDefaultFirewall(apiClient *civogo.Client, networkID string, networkName string) error {

--- a/civo/network/resource_network.go
+++ b/civo/network/resource_network.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -96,6 +97,7 @@ func ResourceNetwork() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		CustomizeDiff: customizeDiffNetwork,
 	}
 }
 
@@ -258,4 +260,11 @@ func expandStringList(input interface{}) []string {
 		}
 	}
 	return result
+}
+
+func customizeDiffNetwork(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	if d.Id() != "" && d.HasChange("cidr_v4") {
+		return fmt.Errorf("the 'cidr_v4' field is immutable")
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes: #233 

Since CIDR is immutable via API, applying the same over here. 
The `CustomizeDiff`  function allows us to perform custom validation during the diff phase and can be used to detect changes to the `cidr_v4`  field and return an error if a change is detected.

This would throw an error in the planning phase itself.
<img width="856" alt="Screenshot 2024-06-23 at 11 23 32 AM" src="https://github.com/civo/terraform-provider-civo/assets/72073401/1c83c044-652c-4cf4-9473-a325698b0e8f">

The below change will throw error error when terraform apply is done hence this approach is not preferable.

```
func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
	apiClient := m.(*civogo.Client)

	// overwrite the region if is defined in the datasource
	if region, ok := d.GetOk("region"); ok {
		apiClient.Region = region.(string)
	}
	
	if d.HasChange("cidr_v4") {
		return diag.Errorf("the 'cidr_v4' field is immutable")
	}

	if d.HasChange("label") {
		log.Printf("[INFO] updating the network %s", d.Id())
		_, err := apiClient.RenameNetwork(d.Get("label").(string), d.Id())
		if err != nil {
			return diag.Errorf("[ERR] An error occurred while rename the network %s", d.Id())
		}
		return resourceNetworkRead(ctx, d, m)
	}
	return resourceNetworkRead(ctx, d, m)
}
```
