### PR TITLE
Feat: fallback to CLI config for token

### DIFF
--- a/civo/provider.go
+++ b/civo/provider.go
@@ -42,7 +42,7 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CIVO_TOKEN", ""),
 				Description: "This is the Civo API token. Alternatively, this can also be specified using `CIVO_TOKEN` environment variable.",
-				Deprecated:  "\"token\" attribute is deprecated. Moving forward, please use \"credential_file\" attribute.",
+				Deprecated:  "\"token\" attribute is deprecated. Moving forward, please set the appropriate environment variable or use the \"credential_file\" attribute.",
 			},
 			"credential_file": {
 				Type:        schema.TypeString,
@@ -145,8 +145,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 func getToken(d *schema.ResourceData) (interface{}, bool) {
 	var exists = true
 
-	// Check for CIVO_TOKEN environment variable
-	if token := os.Getenv("CIVO_TOKEN"); token != "" {
+	// Gets you the token atrribute value or falls back to reading CIVO_TOKEN environment variable
+	if token, ok := d.GetOk("token"); ok {
 		return token, exists
 	}
 

--- a/civo/provider.go
+++ b/civo/provider.go
@@ -47,7 +47,7 @@ func Provider() *schema.Provider {
 				Deprecated:       "",
 				ValidateDiagFunc: validateTokenUsage,
 			},
-			"credential_file": {
+			"credentials_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CIVO_CREDENTIAL_FILE", ""),
@@ -121,7 +121,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	if token, ok := getToken(d); ok {
 		tokenValue = token.(string)
-	} else {		
+	} else {
 		return nil, fmt.Errorf("[ERR] No token configuration found in $CIVO_TOKEN or ~/.civo.json. Please go to https://dashboard.civo.com/security to fetch one")
 	}
 
@@ -154,7 +154,7 @@ func getToken(d *schema.ResourceData) (interface{}, bool) {
 	}
 
 	// Check for credentials file specified in provider config
-	if credFile, ok := d.GetOk("credential_file"); ok {
+	if credFile, ok := d.GetOk("credentials_file"); ok {
 		token, err := readTokenFromFile(credFile.(string))
 		if err == nil {
 			return token, exists
@@ -226,7 +226,7 @@ func validateTokenUsage(v interface{}, path cty.Path) diag.Diagnostics {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
 			Summary:  "Deprecated Attribute Usage",
-			Detail:   "The \"token\" attribute is deprecated. Please use the CIVO_TOKEN environment variable or the credential_file attribute instead.",
+			Detail:   "The \"token\" attribute is deprecated. Please use the CIVO_TOKEN environment variable or the credentials_file attribute instead.",
 		})
 	}
 

--- a/civo/provider.go
+++ b/civo/provider.go
@@ -37,6 +37,13 @@ var (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CIVO_TOKEN", ""),
+				Description: "This is the Civo API token. Alternatively, this can also be specified using `CIVO_TOKEN` environment variable.",
+				Deprecated:  "\"token\" attribute is deprecated. Moving forward, please use \"credential_file\" attribute.",
+			},
 			"credential_file": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/civo/provider.go
+++ b/civo/provider.go
@@ -121,8 +121,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	if token, ok := getToken(d); ok {
 		tokenValue = token.(string)
-	} else {
-		return nil, fmt.Errorf("[ERR] token not found")
+	} else {		
+		return nil, fmt.Errorf("[ERR] No token configuration found in $CIVO_TOKEN or ~/.civo.json. Please go to https://dashboard.civo.com/security to fetch one")
 	}
 
 	if apiEndpoint, ok := d.GetOk("api_endpoint"); ok {

--- a/civo/provider_test.go
+++ b/civo/provider_test.go
@@ -56,7 +56,7 @@ func TestToken(t *testing.T) {
 
 		credentialFile := filepath.Join(tempDir, "credential.json")
 		testToken := "file3409"
-		credContent := fmt.Sprintf(`{"apikeys":{"CIVO_TOKEN":"%s"}}`, testToken)
+		credContent := fmt.Sprintf(`{"apikeys":{"CIVO_TOKEN":"%s"}, "meta":{"current_apikey":"CIVO_TOKEN"}}`, testToken)
 		err = os.WriteFile(credentialFile, []byte(credContent), 0600)
 		if err != nil {
 			t.Fatalf("Failed to write credentials file: %v", err)
@@ -76,7 +76,7 @@ func TestToken(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		testToken := "12345"
+		testToken := "cliconfig12345"
 		cliConfigContent := fmt.Sprintf(`
 			{
 				"apikeys": {

--- a/civo/provider_test.go
+++ b/civo/provider_test.go
@@ -28,6 +28,15 @@ func TestProvider_impl(t *testing.T) {
 
 // TestToken tests the token configuration
 func TestToken(t *testing.T) {
+	t.Run("reading token from token attribute", func(t *testing.T) {
+		const testToken = "123456789"
+
+		raw := map[string]interface{}{
+			"token": testToken,
+		}
+		configureProvider(t, raw)
+	})
+
 	t.Run("reading token from environment variable", func(t *testing.T) {
 		const testToken = "env12345"
 		oldToken := os.Getenv("CIVO_TOKEN")

--- a/civo/provider_test.go
+++ b/civo/provider_test.go
@@ -63,7 +63,7 @@ func TestToken(t *testing.T) {
 		}
 
 		raw := map[string]interface{}{
-			"credential_file": credentialFile,
+			"credentials_file": credentialFile,
 		}
 		configureProvider(t, raw)
 	})

--- a/civo/provider_test.go
+++ b/civo/provider_test.go
@@ -2,6 +2,9 @@ package civo
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"testing"
@@ -25,15 +28,77 @@ func TestProvider_impl(t *testing.T) {
 
 // TestToken tests the token configuration
 func TestToken(t *testing.T) {
-	rawProvider := Provider()
-	raw := map[string]interface{}{
-		"token": "123456789",
-	}
+	t.Run("reading token from environment variable", func(t *testing.T) {
+		const testToken = "env12345"
+		oldToken := os.Getenv("CIVO_TOKEN")
+		os.Setenv("CIVO_TOKEN", testToken)
+		defer os.Setenv("CIVO_TOKEN", oldToken) // Restore the original value
 
-	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
-	if diags.HasError() {
-		t.Fatalf("provider configure failed: %s", diagnosticsToString(diags))
-	}
+		raw := map[string]interface{}{}
+		configureProvider(t, raw)
+	})
+
+	t.Run("reading token from credential file", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "civo-provider-test")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		credentialFile := filepath.Join(tempDir, "credential.json")
+		testToken := "file3409"
+		credContent := fmt.Sprintf(`{"apikeys":{"CIVO_TOKEN":"%s"}}`, testToken)
+		err = os.WriteFile(credentialFile, []byte(credContent), 0600)
+		if err != nil {
+			t.Fatalf("Failed to write credentials file: %v", err)
+		}
+
+		raw := map[string]interface{}{
+			"credential_file": credentialFile,
+		}
+		configureProvider(t, raw)
+	})
+
+	t.Run("reading token from CLI config", func(t *testing.T) {
+		// Create a mock CLI config file
+		tempDir, err := os.MkdirTemp("", "civo-cli-config-test")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		testToken := "12345"
+		cliConfigContent := fmt.Sprintf(`
+			{
+				"apikeys": {
+					"CIVO_TOKEN": "%s"
+				},
+				"meta": {
+					"admin": false,
+					"current_apikey": "CIVO_TOKEN",
+					"default_region": "NYC1",
+					"latest_release_check": "2024-07-07T14:07:51.996201195+05:30",
+					"url": "https://api.civo.com",
+					"last_command_executed": "2024-06-20T15:09:00.212548723+05:30"
+				},
+				"region_to_features": null
+			}`, testToken)
+
+		cliConfigFile := filepath.Join(tempDir, ".civo.json")
+		err = os.WriteFile(cliConfigFile, []byte(cliConfigContent), 0600)
+		if err != nil {
+			t.Fatalf("Failed to write CLI config file: %v", err)
+		}
+
+		// Temporarily set HOME to our temp directory
+		oldHome := os.Getenv("HOME")
+		os.Setenv("HOME", tempDir)
+		defer os.Setenv("HOME", oldHome)
+
+		raw := map[string]interface{}{}
+		configureProvider(t, raw)
+	})
+
 }
 
 func diagnosticsToString(diags diag.Diagnostics) string {
@@ -43,4 +108,14 @@ func diagnosticsToString(diags diag.Diagnostics) string {
 	}
 
 	return strings.Join(diagsAsStrings, "; ")
+}
+
+func configureProvider(t testing.TB, raw map[string]interface{}) {
+	t.Helper()
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	if diags.HasError() {
+		t.Fatalf("provider configure failed: %s", diagnosticsToString(diags))
+	}
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,5 +1,5 @@
-# Set the variable value in *.tfvars file or using -var="civo_token=..." CLI flag
-variable "civo_token" {}
+# Set the variable value in *.tfvars file or using -var="credential_file=..." CLI flag
+variable "credential_file" {}
 
 # Specify required provider as maintained by civo
 terraform {
@@ -12,7 +12,7 @@ terraform {
 
 # Configure the Civo Provider
 provider "civo" {
-  token = var.civo_token
+  credential_file = var.credential_file
   region = "LON1"
 }
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,5 +1,5 @@
-# Set the variable value in *.tfvars file or using -var="credential_file=..." CLI flag
-variable "credential_file" {}
+# Set the variable value in *.tfvars file or using -var="credentials_file=..." CLI flag
+variable "credentials_file" {}
 
 # Specify required provider as maintained by civo
 terraform {
@@ -12,7 +12,7 @@ terraform {
 
 # Configure the Civo Provider
 provider "civo" {
-  credential_file = var.credential_file
+  credentials_file = var.credentials_file
   region = "LON1"
 }
 

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -33,7 +33,6 @@ if [ -z `which civo` ]; then
    exit
 fi
 
-civo_api_key=`civo apikey show | tail -n +4 | head -1 | awk '{print $4}'`
 
 # verify terraform is installed
 if [ -z `which terraform` ]; then
@@ -81,7 +80,6 @@ terraform {
   }
 }
 provider "civo" {
-  token = "$civo_api_key"
   region = "$region"
 }
 EOF

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -33,6 +33,7 @@ if [ -z `which civo` ]; then
    exit
 fi
 
+civo_api_key=`civo apikey show | tail -n +4 | head -1 | awk '{print $4}'`
 
 # verify terraform is installed
 if [ -z `which terraform` ]; then
@@ -80,6 +81,7 @@ terraform {
   }
 }
 provider "civo" {
+  token = "$civo_api_key"
   region = "$region"
 }
 EOF
@@ -96,5 +98,3 @@ echo "${GREEN}Init${RESET} civo provider..."
 terraform init
 terraform plan
 printf "To apply desired resources, you can now use \n ${YELLOW}cd manifests_folder \n terraform apply${RESET}\n"
-
-


### PR DESCRIPTION
This pull request introduces the feature requested in #246 

It Implements a priority-based token retrieval:
1. Environment variable (CIVO_TOKEN).
2. Token provided via a Credential file.
3. Lastly, fall back to CLI config file (~/.civo.json)

**Tests'  Screenshots:**

I have introduced coloured debug messages(removed from the main code), which correctly prints the token it abstracts:

<img width="602" alt="Screenshot 2024-07-08 213657" src="https://github.com/civo/terraform-provider-civo/assets/42026111/6e9775bb-ad6f-4894-b036-ee47e33ebd6b">

Below, I have set the token using Civo CLI command `civo apikey save CIVO_TOKEN clitoken96` which saves it in `~/.civo.json`.
You can see, it correctly prints a different token(last coloured debug message):

<img width="616" alt="Screenshot 2024-07-08 214536" src="https://github.com/civo/terraform-provider-civo/assets/42026111/59990e4f-82d9-4194-b7ab-30f84efed621">
