### PR TITLE
Fix: Error out when changing applications field in civo_kubernetes_cluster

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -368,9 +368,9 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	// Update the node pool if necessary
-	if !d.HasChange("pools") {
-		return resourceKubernetesClusterRead(ctx, d, m)
-	}
+	// if !d.HasChange("pools") {
+	// 	return resourceKubernetesClusterRead(ctx, d, m)
+	// }
 
 	if d.HasChange("pools") {
 		old, new := d.GetChange("pools")
@@ -408,8 +408,9 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange("applications") {
-		config.Applications = d.Get("applications").(string)
-		config.Region = apiClient.Region
+		// config.Applications = d.Get("applications").(string)
+		// config.Region = apiClient.Region
+		return diag.Errorf("[ERR] applications cannot be changed or removed after the kubernetes cluster has been created")
 	}
 
 	if d.HasChange("name") {


### PR DESCRIPTION
This PR aims to address the issue in #258 .

In here, 

1. I have returned an error from the `if()` block which checks for any change in the `applications` field.

2. I have commented out a seemingly redundant piece of code, which made the `HasChange` check for `applications` field unreachable in case there is no change in `pools` attribute of the `civo_kubernetes_cluster`.

Relevant screenshots from the result:

1. Resource created successfully:

<img width="876" alt="Screenshot 2024-07-18 200352" src="https://github.com/user-attachments/assets/72a79ac1-e4f5-4555-97e8-8e6c3498ae36">

2. Changes made to `applications` field in `main.tf`, getting correctly reflected in the terraform plan:

<img width="606" alt="Screenshot 2024-07-18 200444" src="https://github.com/user-attachments/assets/65c031af-eaa5-49d4-b133-98dda1e128fb">

3. Error getting correctly logged:

<img width="875" alt="Screenshot 2024-07-18 200520" src="https://github.com/user-attachments/assets/c30e303c-0b18-4435-a5bb-24fd887c3a6f">

