### PR TITLE
Fix: Error out when changing cluster_type in civo_kubernetes_cluster after creation

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -367,6 +367,10 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("[ERR] Firewall change (%q) for existing cluster is not available at this moment", "firewall_id")
 	}
 
+	if d.HasChange("cluster_type") {
+		return diag.Errorf("[ERR] cluster_type cannot be changed after cluster has been created. If you wish to change the cluster type, either create another cluster of a different type or destroy this one first")
+	}
+
 	// Update the node pool if necessary
 	if !d.HasChange("pools") {
 		return resourceKubernetesClusterRead(ctx, d, m)


### PR DESCRIPTION
This PR addresses the issue #259.

In Here,

1. I added a check to detect update in `cluster_type` attribute of the `civo_kubernetes_cluster`. If detected, it correctly returns an error.

Relevant screenshots from the result:

1. Successful resource creation:

<img width="757" alt="Screenshot 2024-07-18 205819" src="https://github.com/user-attachments/assets/a790cb94-5c08-4aab-ab75-94a2ac47eb84">

2. Changes made to `cluster_type` field, getting correctly reflected in the terraform plan:

<img width="615" alt="Screenshot 2024-07-18 205933" src="https://github.com/user-attachments/assets/74361bf6-4294-43e7-b281-068e81c9ce67">

3. Error getting shown correctly:

<img width="751" alt="Screenshot 2024-07-18 210000" src="https://github.com/user-attachments/assets/dcd119dd-4d2d-4e0f-b345-7155b2d1abf4">

