### PR TITLE
fix: allow updating kubernetes_version after cluster creation

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -370,9 +370,9 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	// Update the node pool if necessary
-	if !d.HasChange("pools") {
-		return resourceKubernetesClusterRead(ctx, d, m)
-	}
+	// if !d.HasChange("pools") {
+	// 	return resourceKubernetesClusterRead(ctx, d, m)
+	// }
 
 	if d.HasChange("pools") {
 		old, new := d.GetChange("pools")
@@ -404,9 +404,8 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange("kubernetes_version") {
-		// config.KubernetesVersion = d.Get("kubernetes_version").(string)
-		// config.Region = apiClient.Region
-		return diag.Errorf("[ERR] Kubernetes version upgrade (%q attribute) is not supported yet", "kubernetes_version")
+		config.KubernetesVersion = d.Get("kubernetes_version").(string)
+		config.Region = apiClient.Region
 	}
 
 	if d.HasChange("applications") {


### PR DESCRIPTION
This PR fixes #261 


**Screenshots:**

Current Behaviour:

Says modification applied:

<img width="616" alt="Screenshot 2024-07-23 145531" src="https://github.com/user-attachments/assets/21bad218-c546-45d8-bcc0-75c841279ee1">

But cluster's state remains the same:

<img width="339" alt="Screenshot 2024-07-23 145656" src="https://github.com/user-attachments/assets/913edebe-378e-4221-a6b8-de19f97f62b0">

`main.tf`:

<img width="413" alt="Screenshot 2024-07-23 145633" src="https://github.com/user-attachments/assets/2a4c85bb-298f-4bc3-a25e-86d701de177e">


After changes:

Cluster updating:

<img width="387" alt="Screenshot 2024-07-23 150438" src="https://github.com/user-attachments/assets/cebd0011-5557-4980-b94e-50aabe83bb10">

Cluster updated with a new `kubernetes_version`:

<img width="263" alt="Screenshot 2024-07-23 150610" src="https://github.com/user-attachments/assets/61a47376-07b0-4f21-8fc2-96612631d1d2">

