### PR TITLE
fix: support updating firewall_id for civo_kubernetes_cluster

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -366,7 +366,8 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if d.HasChange("firewall_id") {
-		return diag.Errorf("[ERR] Firewall change (%q) for existing cluster is not available at this moment", "firewall_id")
+		config.FirewallID = d.Get("firewall_id").(string)
+		config.Region = apiClient.Region
 	}
 
 	// Update the node pool if necessary

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/civo/terraform-provider-civo
 
 require (
-	github.com/civo/civogo v0.3.70
+	github.com/civo/civogo v0.3.73
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/civo/civogo v0.3.70 h1:QPuFm5EmpkScbdFo5/6grcG2xcvd/lgdolOtENT04Ac=
 github.com/civo/civogo v0.3.70/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
+github.com/civo/civogo v0.3.73 h1:thkNnkziU+xh+MEOChIUwRZI1forN20+SSAPe/VFDME=
+github.com/civo/civogo v0.3.73/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=


### PR DESCRIPTION
This PR fixes #262 

In here,

1. The provider was using `civogo` version `v0.3.70`, and now has been updated to `v0.3.73` to pull the latest changes necessary to fix this issue.

2. The code also updates the cluster's configuration with the new `firewall_id`, allowing users to update post creation.

Screenshots:

Created with `my-firewall`:

<img width="349" alt="Screenshot 2024-07-23 193951" src="https://github.com/user-attachments/assets/6866d16a-3750-48b5-b796-e215c2b87159">

Modification to `firewall_id` successfully applied:

<img width="358" alt="Screenshot 2024-07-23 194049" src="https://github.com/user-attachments/assets/d9f5f494-3149-4b51-bb32-4d26900a9d70">

Post update, using `my-firewall2`:

<img width="342" alt="Screenshot 2024-07-23 194109" src="https://github.com/user-attachments/assets/fa62b6db-099c-4a53-8540-9710fe0e9e3a">
