### PR TITLE
fix: validate cluster_type to ensure it is either 'k3s' or 'talos'

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -91,10 +91,10 @@ func ResourceKubernetesCluster() *schema.Resource {
 				Description: "The existing firewall ID to use for this cluster",
 			},
 			"cluster_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				Description: "The type of cluster to create, valid options are `k3s` or `talos` the default is `k3s`",
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				Description:      "The type of cluster to create, valid options are `k3s` or `talos` the default is `k3s`",
 				ValidateDiagFunc: utils.ValidateClusterType,
 			},
 			// Computed resource

--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -95,6 +95,7 @@ func ResourceKubernetesCluster() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "The type of cluster to create, valid options are `k3s` or `talos` the default is `k3s`",
+				ValidateDiagFunc: utils.ValidateClusterType,
 			},
 			// Computed resource
 			"installed_applications": applicationSchema(),

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -178,10 +178,10 @@ func InPool(id string, list []civogo.KubernetesClusterPoolConfig) bool {
 func ValidateClusterType(v interface{}, path cty.Path) diag.Diagnostics {
 	val := v.(string)
 	var diags diag.Diagnostics
-	if val != "k3s" && val != "talos"{
+	if val != "k3s" && val != "talos" {
 
 		diags = append(diags, diag.Diagnostic{
-		Severity: diag.Error,
+			Severity: diag.Error,
 			Summary:  "Invalid Cluster Type",
 			Detail:   "The specified cluster type is invalid. Please choose either 'k3s' or 'talos'.",
 		})

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -174,6 +174,21 @@ func InPool(id string, list []civogo.KubernetesClusterPoolConfig) bool {
 	return false
 }
 
+// Validates if the user has provided a supported cluster type.
+func ValidateClusterType(v interface{}, path cty.Path) diag.Diagnostics {
+	val := v.(string)
+	var diags diag.Diagnostics
+	if val != "k3s" && val != "talos"{
+
+		diags = append(diags, diag.Diagnostic{
+		Severity: diag.Error,
+			Summary:  "Invalid Cluster Type",
+			Detail:   "The specified cluster type is invalid. Please choose either 'k3s' or 'talos'.",
+		})
+	}
+	return diags
+}
+
 // CustomError captures a specific portion of the full API error
 type CustomError struct {
 	Code   string `json:"code"`

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -174,7 +174,7 @@ func InPool(id string, list []civogo.KubernetesClusterPoolConfig) bool {
 	return false
 }
 
-// Validates if the user has provided a supported cluster type.
+// ValidateClusterType Validates if the user has provided a supported cluster type.
 func ValidateClusterType(v interface{}, path cty.Path) diag.Diagnostics {
 	val := v.(string)
 	var diags diag.Diagnostics


### PR DESCRIPTION
This PR fixes #277 

In here:

I added validation for the `cluster_type` attribute to ensure it only accepts `k3s` or `talos`. This prevents defaulting to `k3s` when an invalid value is provided.

Result:

<img width="485" alt="Screenshot 2024-07-23 234340" src="https://github.com/user-attachments/assets/02e11908-4164-4f7e-9039-4ca5ff522f0d">
