### PR TITLE
fix: handle application plans with spaces

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -241,7 +241,7 @@ func resourceKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData
 
 	if attr, ok := d.GetOk("applications"); ok {
 		if utils.CheckAPPName(attr.(string), apiClient) {
-			config.Applications = strings.ReplaceAll(attr.(string), " ", "")
+			config.Applications = attr.(string)
 		} else {
 			return diag.Errorf("[ERR] the app that tries to install is not valid: %s", attr.(string))
 		}


### PR DESCRIPTION
This PR fixes #284 

The changes ensure that application plans with spaces (e.g., 'Linkerd with Dashboard & Jaeger') are correctly processed in the Terraform provider, matching the behavior of the CLI.

Result:

`main.tf`:

<img width="452" alt="Screenshot 2024-07-27 165517" src="https://github.com/user-attachments/assets/22b7f5c5-5afd-4e43-a64e-d42f3996a38b">

Successful resource Creation:

<img width="340" alt="Screenshot 2024-07-27 164617" src="https://github.com/user-attachments/assets/2358baad-42f7-463a-b3f6-0d148fef3114">

Dashboard correctly showing the applications installed:

<img width="783" alt="Screenshot 2024-07-27 164545" src="https://github.com/user-attachments/assets/e49871ce-406d-4dc9-9703-63c59e1a4b9b">

