### PR TITLE
Make saving kubeconfig to state optional for civo_kubernetes resource

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -129,7 +129,7 @@ func ResourceKubernetesCluster() *schema.Resource {
 				Optional:         true,
 				Default:          false,
 				Description:      "Whether to write the kubeconfig to state",
-				ValidateDiagFunc: utils.ValidateWriteKubeconfig,
+				ValidateDiagFunc: utils.ValidateProviderVersion,
 			},
 			"api_endpoint": {
 				Type:        schema.TypeString,

--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -124,6 +124,13 @@ func ResourceKubernetesCluster() *schema.Resource {
 				Sensitive:   true,
 				Description: "The kubeconfig of the cluster",
 			},
+			"write_kubeconfig": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				Description:      "Whether to write the kubeconfig to state",
+				ValidateDiagFunc: utils.ValidateWriteKubeconfig,
+			},
 			"api_endpoint": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -332,13 +339,20 @@ func resourceKubernetesClusterRead(_ context.Context, d *schema.ResourceData, m 
 	d.Set("tags", strings.Join(resp.Tags, " ")) // space separated tags
 	d.Set("status", resp.Status)
 	d.Set("ready", resp.Ready)
-	d.Set("kubeconfig", resp.KubeConfig)
+	// d.Set("kubeconfig", resp.KubeConfig)
 	d.Set("api_endpoint", resp.APIEndPoint)
 	d.Set("master_ip", resp.MasterIP)
 	d.Set("dns_entry", resp.DNSEntry)
 	// d.Set("built_at", resp.BuiltAt.UTC().String())
 	d.Set("created_at", resp.CreatedAt.UTC().String())
 	d.Set("firewall_id", resp.FirewallID)
+
+	writeKubeconfig := d.Get("write_kubeconfig").(bool)
+	if writeKubeconfig {
+		d.Set("kubeconfig", resp.KubeConfig)
+	} else {
+		d.Set("kubeconfig", "")
+	}
 
 	if err := d.Set("pools", flattenNodePool(resp)); err != nil {
 		return diag.Errorf("[ERR] error retrieving the pool for kubernetes cluster error: %#v", err)
@@ -422,6 +436,11 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange("tags") {
 		config.Tags = d.Get("tags").(string)
+	}
+
+	if d.HasChange("write_kubeconfig") {
+		// setting atleast one field inside the KubernetesClusterConfig, just to ensure we are not sending an empty config
+		config.FirewallID = d.Get("firewall_id").(string)
 	}
 
 	log.Printf("[INFO] updating the kubernetes cluster %s", d.Id())

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/civo/civogo v0.3.73
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
+	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.25.0
@@ -30,7 +31,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.6.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.19.1 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmms
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/civo/civogo v0.3.70 h1:QPuFm5EmpkScbdFo5/6grcG2xcvd/lgdolOtENT04Ac=
-github.com/civo/civogo v0.3.70/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
 github.com/civo/civogo v0.3.73 h1:thkNnkziU+xh+MEOChIUwRZI1forN20+SSAPe/VFDME=
 github.com/civo/civogo v0.3.73/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
@@ -78,8 +76,8 @@ github.com/hashicorp/go-plugin v1.6.0/go.mod h1:lBS5MtSSBZk0SHc66KACcjjlU6WzEVP/
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
-github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.6.2 h1:V1k+Vraqz4olgZ9UzKiAcbman9i9scg9GgSt/U3mw/M=
 github.com/hashicorp/hc-install v0.6.2/go.mod h1:2JBpd+NCFKiHiu/yYCGaPyPHhZLxXTpz8oreHa/a3Ps=
 github.com/hashicorp/hcl/v2 v2.19.1 h1://i05Jqznmb2EXqa39Nsvyan2o5XyMowW5fnCKW5RPI=


### PR DESCRIPTION
This PR fixes #296 

In here,

1. I introduced a new boolean configuration `write_kubeconfig` to control whether the kubeconfig is written to the Terraform state.
2. Defaulted `write_kubeconfig` to false.
3. Added a warning message to inform users about the new behavior. It flashes when users' provider version is `<=1.0.49`(current one)

**I tested again, and here are the results:**

`main.tf`: no `write_kubeconfig` specified.

<img width="313" alt="Screenshot 2024-08-07 232316" src="https://github.com/user-attachments/assets/45ca4eb5-a284-451d-8522-a7b13c495a22">

correctly defaulting to `false`:

<img width="304" alt="Screenshot 2024-08-07 232355" src="https://github.com/user-attachments/assets/9f10b7f5-73a1-4d6a-bc3d-e0cb8f784bc9">

successful resource creation:

<img width="357" alt="Screenshot 2024-08-07 232916" src="https://github.com/user-attachments/assets/9cfab47c-c155-4a8d-baef-9d4c447581a9">

`kubeconfig` rightly hidden:

<img width="905" alt="Screenshot 2024-08-07 232854" src="https://github.com/user-attachments/assets/3aa259b1-9b09-4a1e-9a6c-382b22dde248">

updating configuration:

<img width="297" alt="image" src="https://github.com/user-attachments/assets/995daed7-62ca-42b6-8a68-fe16cebece9a">

correctly planned:

<img width="272" alt="Screenshot 2024-08-07 233018" src="https://github.com/user-attachments/assets/c40f836e-6273-4848-b7ff-d54ae24cfcda">

Update successful:

<img width="346" alt="Screenshot 2024-08-07 233055" src="https://github.com/user-attachments/assets/9eb50736-7cc2-49c2-88e1-dc2312557401">

`kubeconfig` rightly written to state:

<img width="908" alt="Screenshot 2024-08-07 233208" src="https://github.com/user-attachments/assets/2973a88d-cafd-449f-b567-f4a40fd6f216">

Updating again:

<img width="302" alt="Screenshot 2024-08-07 233130" src="https://github.com/user-attachments/assets/566a7c8e-b1b0-4341-87c2-be62d899a72b">

<img width="251" alt="Screenshot 2024-08-07 233253" src="https://github.com/user-attachments/assets/7f5681e0-c0ab-4429-b7f3-5e253d7563ab">
