### PR TITLE
default k8s version is latest stable available

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -60,7 +60,7 @@ func ResourceKubernetesCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "The version of k3s to install (optional, the default is currently the latest available)",
+				Description: "The version of k3s to install (optional, the default is currently the latest stable available)",
 			},
 			"cni": {
 				Type:         schema.TypeString,

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -203,7 +203,7 @@ Required:
 - `applications` (String) Comma separated list of applications to install. Spaces within application names are fine, but shouldn't be either side of the comma. Application names are case-sensitive; the available applications can be listed with the Civo CLI: 'civo kubernetes applications ls'. If you want to remove a default installed application, prefix it with a '-', e.g. -Traefik. For application that supports plans, you can use 'app_name:app_plan' format e.g. 'Linkerd:Linkerd & Jaeger' or 'MariaDB:5GB'. View list of apps on the [Civo CLI](https://www.civo.com/docs/overview/civo-cli) --> `civo kubernetes apps ls`
 - `cluster_type` (String) The type of cluster to create, valid options are `k3s` or `talos` the default is `k3s`
 - `cni` (String) The cni for the k3s to install (the default is `flannel`) valid options are `cilium` or `flannel`
-- `kubernetes_version` (String) The version of k3s to install (optional, the default is currently the latest available)
+- `kubernetes_version` (String) The version of k3s to install (optional, the default is currently the latest stable available)
 - `name` (String) Name for your cluster, must be unique within your account
 - `network_id` (String) The network for the cluster, if not declare we use the default one
 - `num_target_nodes` (Number, Deprecated) The number of instances to create (optional, the default at the time of writing is 3)


### PR DESCRIPTION
Based on some feedback in the community we discovered it would be more helpful to clarify that the latest k8s version if unspecified is not just the latest available but additionally is the latest **stable** as well within a given cluster type if version is not specified.

```c
date && civo k8s versions
Tue Aug 13 03:34:15 PM EDT 2024
+--------------+--------------+--------------+-------------+---------+
| Name         | K8s version  | Cluster-Type | Maturity    | Default |
+--------------+--------------+--------------+-------------+---------+
| 1.27.11-k3s1 | 1.27.11-k3s1 | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| talos-v1.2.8 | 1.25.5       | talos        | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.28.2-k3s1  | 1.28.2-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.22.2-k3s1  | 1.22.2-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.26.14-k3s1 | 1.26.14-k3s1 | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| talos-v1.5.0 | 1.27.0       | talos        | stable      | true    |
+--------------+--------------+--------------+-------------+---------+
| 1.29.2-k3s1  | 1.29.2-k3s1  | k3s          | development | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.27.1-k3s1  | 1.27.1-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.25.9-k3s1  | 1.25.9-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.28.7-k3s1  | 1.28.7-k3s1  | k3s          | stable      | true    |
+--------------+--------------+--------------+-------------+---------+
| 1.24.13-k3s1 | 1.24.13-k3s1 | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.26.4-k3s1  | 1.26.4-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.23.6-k3s1  | 1.23.6-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.25.0-k3s1  | 1.25.0-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.21.2-k3s1  | 1.21.2-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.24.4-k3s1  | 1.24.4-k3s1  | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
| 1.22.11-k3s1 | 1.22.11-k3s1 | k3s          | deprecated  | false   |
+--------------+--------------+--------------+-------------+---------+
```