### PR TITLE
honor Talos version string when creating clusters

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -522,7 +522,7 @@ func customizeDiffKubernetesCluster(ctx context.Context, d *schema.ResourceDiff,
 	if kubeVersion, ok := d.GetOk("kubernetes_version"); ok {
 		version := kubeVersion.(string)
 		var k3sVersionRegex = regexp.MustCompile(`^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-k3s\d$`)
-		var talosVersionRegex = regexp.MustCompile(`^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
+		var talosVersionRegex = regexp.MustCompile(`^talos-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`)
 
 		clusterType := "k3s" // Default
 		attr, ok := d.GetOk("cluster_type")
@@ -543,9 +543,9 @@ func customizeDiffKubernetesCluster(ctx context.Context, d *schema.ResourceDiff,
 			if kv.ClusterType == clusterType {
 				switch kv.Type {
 				case "stable":
-					stableVersions = append(stableVersions, kv.Version)
+					stableVersions = append(stableVersions, kv.Label)
 				case "development":
-					developmentVersions = append(developmentVersions, kv.Version)
+					developmentVersions = append(developmentVersions, kv.Label)
 				}
 			}
 		}
@@ -564,9 +564,9 @@ func customizeDiffKubernetesCluster(ctx context.Context, d *schema.ResourceDiff,
 			isValidVersion = talosVersionRegex.MatchString(version)
 			if !isValidVersion {
 				return fmt.Errorf("invalid Kubernetes version format: '%s' for cluster type '%s'.\n\n"+
-					"Please ensure your version matches the expected format, e.g., 'X.Y.Z'.\n\n"+
-					"Available versions for '%s':\n- Stable: %v",
-					version, clusterType, clusterType, stableVersions)
+					"Please ensure your version matches the expected format, e.g., 'talos-vX.Y.Z'.\n\n"+
+					"Available versions for '%s':\n- Stable: %v\n- Development: %v",
+					version, clusterType, clusterType, stableVersions, developmentVersions)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #352 

Result:

`main.tf`:

<img width="301" alt="Screenshot 2024-10-17 182556" src="https://github.com/user-attachments/assets/d9e1fb4a-ea9a-4782-8131-49ea652598c9">

Correctly throwing error:

<img width="463" alt="Screenshot 2024-10-17 182538" src="https://github.com/user-attachments/assets/1c39a838-8b6f-4a17-87e9-7ac089d93915">

Updated the version string:

<img width="310" alt="Screenshot 2024-10-17 182852" src="https://github.com/user-attachments/assets/8f9fd6f5-750a-4b0c-bdd0-226eaff00066">

Resource getting created successfully:

<img width="580" alt="Screenshot 2024-10-17 183412" src="https://github.com/user-attachments/assets/a8a61e4c-cfd7-406d-a219-a57792892d8f">


