### PR TITLE
Fix: Fetch correct label from kubernetes version datasource for talos cluster

### DIFF
--- a/civo/kubernetes/datasource_kubernetes_version.go
+++ b/civo/kubernetes/datasource_kubernetes_version.go
@@ -44,7 +44,7 @@ func flattenKubernetesVersion(version, _ interface{}, _ map[string]interface{}) 
 
 	flattenedVersion := map[string]interface{}{}
 	flattenedVersion["version"] = s.Version
-	flattenedVersion["label"] = fmt.Sprintf("v%s", s.Version)
+	flattenedVersion["label"] = s.Label
 	flattenedVersion["type"] = s.ClusterType
 	flattenedVersion["default"] = s.Default
 	return flattenedVersion, nil

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmms
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/civo/civogo v0.3.84 h1:jf5IT7VJFPaReO6g8B0zqKhsYCIizaGo4PjDLY7Sl6Y=
-github.com/civo/civogo v0.3.84/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
-github.com/civo/civogo v0.3.85 h1:rXRbDT9B60Ocp/IxAoAs90yAJog2la1MajQqgXETxd4=
-github.com/civo/civogo v0.3.85/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
 github.com/civo/civogo v0.3.89 h1:g+I4NGVa5t0L2Z9+QbnEAqxE/3OCDUYvepje3oUkKVo=
 github.com/civo/civogo v0.3.89/go.mod h1:7UCYX+qeeJbrG55E1huv+0ySxcHTqq/26FcHLVelQJM=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=


### PR DESCRIPTION
This fixes #366.


### Result:

**Before:**

<img width="462" alt="Screenshot 2025-01-27 at 7 11 00 PM" src="https://github.com/user-attachments/assets/d6821a5e-9220-4f9f-8a8c-d23cc7271612" />

**After:**

<img width="862" alt="Screenshot 2025-01-27 at 7 18 24 PM" src="https://github.com/user-attachments/assets/325334e4-0436-42aa-8765-d1a1cf91156d" />

<img width="442" alt="Screenshot 2025-01-27 at 7 19 03 PM" src="https://github.com/user-attachments/assets/af96b136-9157-42d6-a182-13351c47c908" />

