### PR TITLE
add attach_on_boot to the resource_volume_attachement schema

### DIFF
--- a/civo/volume/resource_volume_attachment.go
+++ b/civo/volume/resource_volume_attachment.go
@@ -39,6 +39,13 @@ func ResourceVolumeAttachment() *schema.Resource {
 				ForceNew:    true,
 				Description: "The region for the volume attachment",
 			},
+			"attach_at_boot": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: "Whether to attach the instance to the volume at boot",
+			},
 		},
 		CreateContext: resourceVolumeAttachmentCreate,
 		ReadContext:   resourceVolumeAttachmentRead,

--- a/civo/volume/resource_volume_attachment_test.go
+++ b/civo/volume/resource_volume_attachment_test.go
@@ -37,6 +37,7 @@ func TestAccCivoVolumeAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "id"),
 					resource.TestCheckResourceAttrSet(resName, "instance_id"),
 					resource.TestCheckResourceAttrSet(resName, "volume_id"),
+					resource.TestCheckResourceAttrSet(resName, "attach_on_boot"),
 				),
 			},
 		},
@@ -98,6 +99,7 @@ resource "civo_volume_attachment" "foobar" {
 	instance_id = civo_instance.vm.id
 	volume_id  = civo_volume.foo.id
 	region = "LON1"
+    attach_on_boot = true
 }
 `, name, name)
 }


### PR DESCRIPTION
`attach_on_boot` is used in the `resource_volume_attachment` but isn't defined in the schema