### PR TITLE
docs: interaction between instances and reserved ip

### DIFF
--- a/docs/resources/instance_reserved_ip_assignment.md
+++ b/docs/resources/instance_reserved_ip_assignment.md
@@ -8,7 +8,7 @@ description: |-
 
 # civo_instance_reserved_ip_assignment (Resource)
 
-The instance reserved ip assignment resource schema definition
+The instance reserved ip assignment resource schema definition. If you are using this resource to assign a reserved IP to an instance, instances `public_ip` attribute won't be updated until the next state refresh. If subsequent resources are relying instances public IP consider assigning the reserved ip address to the instance.
 
 ## Example Usage
 

--- a/docs/resources/reserved_ip.md
+++ b/docs/resources/reserved_ip.md
@@ -12,9 +12,31 @@ Provides a Civo reserved IP to represent a publicly-accessible static IP address
 
 ## Example Usage
 
+A `civo_reserved_ip` can be assigned to an `civo-instance` either by setting `reserved_ipv4` field for `civo-instance` or using `civo_instance_reserved_ip_assignment` resource.
+
 ```terraform
 resource "civo_reserved_ip" "www" {
     name = "nginx-www" 
+}
+
+resource "civo_instance" "webserver" {
+    # ...  removed for brevity
+    reserved_ipv4 = civo_reserved_ip.www.ip
+}
+```
+
+```terraform
+resource "civo_reserved_ip" "www" {
+    name = "nginx-www" 
+}
+
+resource "civo_instance" "webserver" {
+    # ...  removed for brevity
+}
+
+resource "civo_instance_reserved_ip_assignment" "webserver-www" {
+    instance_id    = civo_instance.webserver.id
+    reserved_ip_id = civo_reserved_ip.www.id
 }
 ```
 


### PR DESCRIPTION
When using `civo_instance_reserved_ip_assignment` resource to assign a reserved IP address to a `civo_instance` subsequent resources are not able to use it’s `public_ip` attribute, because it is empty.

For example, the following Terraform code snippet creates a reserved ip and an instance, and using `civo_instance_reserved_ip_assignment` resource assign the public IP to the instance. Resources that relay on instance public ip attribute, such as outputting instance IP address, fail. This PR adds a disclaimer and alternative solution.

```bash
resource "civo_reserved_ip" "this" {
...
}

resource "civo_instance" "this" {
...
}

resource "civo_instance_reserved_ip_assignment" "webserver-www" {
  instance_id    = civo_instance.this.id
  reserved_ip_id = civo_reserved_ip.this.id
}

output "public_ip_reservation" {
  value = civo_instance.this.ip
} 
```