### PR TITLE
Update resource_instance_test.go

### DIFF
--- a/civo/instances/resource_instance_test.go
+++ b/civo/instances/resource_instance_test.go
@@ -206,6 +206,158 @@ func TestAccCivoInstanceFirewall_update(t *testing.T) {
 		},
 	})
 }
+//Verify the SSH key ID is correctly set
+func TestAccCivoInstanceSSHKey_update(t *testing.T) {
+	var instance civogo.Instance
+	resName := "civo_instance.foobar"
+	var instanceHostname = acctest.RandomWithPrefix("tf-test") + ".example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CivoInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CivoInstanceConfigSSHKey(instanceHostname),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CivoInstanceResourceExists(resName, &instance),
+					resource.TestCheckResourceAttrSet(resName, "sshkey_id"),
+				),
+			},
+		},
+	})
+}
+
+func CivoInstanceConfigSSHKey(hostname string) string {
+	return fmt.Sprintf(`
+resource "civo_ssh_key" "foobar" {
+    name    = "test-ssh-key"
+    public_key = "ssh-rsa AAAA..."
+}
+
+resource "civo_instance" "foobar" {
+    hostname = "%s"
+    size = "g3.small"
+    disk_image = "debian-10"
+    sshkey_id = civo_ssh_key.foobar.id
+}`, hostname)
+}
+
+func TestAccCivoInstanceReservedIP_update(t *testing.T) {
+	var instance civogo.Instance
+	resName := "civo_instance.foobar"
+	var instanceHostname = acctest.RandomWithPrefix("tf-test") + ".example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CivoInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CivoInstanceConfigReservedIP(instanceHostname),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CivoInstanceResourceExists(resName, &instance),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ip"),
+				),
+			},
+		},
+	})
+}
+//Verify the reserved IP is correctly set.
+func CivoInstanceConfigReservedIP(hostname string) string {
+	return fmt.Sprintf(`
+resource "civo_reserved_ip" "foobar" {
+    name = "test-reserved-ip"
+}
+
+resource "civo_instance" "foobar" {
+    hostname = "%s"
+    size = "g3.small"
+    disk_image = "debian-10"
+    reserved_ip = civo_reserved_ip.foobar.id
+}`, hostname)
+}
+//Test Instance Stop & Start
+func TestAccCivoInstanceStopStart(t *testing.T) {
+	var instance civogo.Instance
+	resName := "civo_instance.foobar"
+	var instanceHostname = acctest.RandomWithPrefix("tf-test") + ".example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CivoInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CivoInstanceConfigBasic(instanceHostname),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CivoInstanceResourceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: CivoInstanceConfigStopped(instanceHostname),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CivoInstanceResourceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "status", "STOPPED"),
+				),
+			},
+			{
+				Config: CivoInstanceConfigBasic(instanceHostname),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CivoInstanceResourceExists(resName, &instance),
+					resource.TestCheckResourceAttr(resName, "status", "ACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func CivoInstanceConfigStopped(hostname string) string {
+	return fmt.Sprintf(`
+resource "civo_instance" "foobar" {
+    hostname = "%s"
+    size = "g3.small"
+    disk_image = "debian-10"
+    stop = true
+}`, hostname)
+}
+//Test Volume Attachment
+func TestAccCivoInstanceVolumeAttachment(t *testing.T) {
+	var instance civogo.Instance
+	resName := "civo_instance.foobar"
+	var instanceHostname = acctest.RandomWithPrefix("tf-test") + ".example"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acceptance.TestAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		CheckDestroy: acceptance.CivoInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CivoInstanceConfigVolumeAttachment(instanceHostname),
+				Check: resource.ComposeTestCheckFunc(
+					acceptance.CivoInstanceResourceExists(resName, &instance),
+					resource.TestCheckResourceAttrSet(resName, "volume_ids"),
+				),
+			},
+		},
+	})
+}
+
+func CivoInstanceConfigVolumeAttachment(hostname string) string {
+	return fmt.Sprintf(`
+resource "civo_volume" "foobar" {
+    name = "test-volume"
+    size_gb = 10
+}
+
+resource "civo_instance" "foobar" {
+    hostname = "%s"
+    size = "g3.small"
+    disk_image = "debian-10"
+    volume_ids = [civo_volume.foobar.id]
+}`, hostname)
+}
 
 func CivoInstanceValues(instance *civogo.Instance, name string) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {


### PR DESCRIPTION
[OTHER] create comprehensive set of tests for instance resource #330

These updates ensure that you can use the SSH key, assign reserved IPs, start examples of new and easy attaching extra storage.