### PR TITLE
fix(#381): nodepool scaling panic on node_count update

### DIFF
--- a/civo/kubernetes/resource_kubernetes_cluster_nodepool.go
+++ b/civo/kubernetes/resource_kubernetes_cluster_nodepool.go
@@ -211,7 +211,8 @@ func resourceKubernetesClusterNodePoolUpdate(ctx context.Context, d *schema.Reso
 	}
 
 	if d.HasChange("node_count") {
-		poolUpdate.Count = d.Get("node_count").(*int)
+		count := d.Get("node_count").(int)
+		poolUpdate.Count = &count
 	}
 
 	if d.HasChange("labels") {


### PR DESCRIPTION
## Summary

Cherry-picks the fix from #389 (commit 230a227, authored by @arkhoss) for the nodepool scaling panic reported in #381. Opening this as a focused, single-commit PR so we can release it ahead of the rest of #389 — the panic is blocking some customers and we're accelerating its release.

Huge thanks to @arkhoss for diagnosing and fixing this; this branch preserves the original author attribution so credit lands on him.

The other commit on #389 (labels/taints propagation, #380) is intentionally **not** included here and should land via #389 once it's rebased.

## Fix

`d.Get("node_count").(*int)` panicked at runtime with:

```
interface conversion: interface {} is int, not *int
```

The Terraform schema declares `node_count` as `TypeInt`, which the SDK stores as a plain `int` — never a `*int`. Replaced with the standard SDK pattern: assert to `int`, then take the address to populate the `*int` `Count` field on `civogo.KubernetesClusterPoolUpdateConfig`.

```go
if d.HasChange("node_count") {
    count := d.Get("node_count").(int)
    poolUpdate.Count = &count
}
```

Closes #381
Original PR: #389
Credit: @arkhoss

## Test plan

- [x] `go build ./...` passes
- [ ] Apply a `civo_kubernetes_node_pool`, change `node_count`, run `terraform apply` — scaling completes without panic
- [ ] Existing acceptance tests pass in CI