### PR TITLE
Chore/bump civogo v0.7.2

### DIFF
--- a/civo/instances/datasource_instances.go
+++ b/civo/instances/datasource_instances.go
@@ -47,13 +47,15 @@ func getDataSourceInstances(m interface{}, extra map[string]interface{}) ([]inte
 	}
 
 	var instance []interface{}
-	partialInstances, err := apiClient.ListInstances(1, 200)
+	// Use ListAllInstances so accounts with > 200 instances are not silently
+	// truncated; civogo v0.7.2 iterates server pagination internally.
+	allInstances, err := apiClient.ListAllInstances()
 	if err != nil {
 		return nil, fmt.Errorf("[ERR] error retrieving instances: %s", err)
 	}
 
-	for _, partialInstance := range partialInstances.Items {
-		instance = append(instance, partialInstance)
+	for _, ins := range allInstances {
+		instance = append(instance, ins)
 	}
 
 	return instance, nil

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/civo/terraform-provider-civo
 
-go 1.25.8
+go 1.25.10
 
 require (
-	github.com/civo/civogo v0.7.0
+	github.com/civo/civogo v0.7.2
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/civo/civogo v0.7.0 h1:XY75Ru7MgjEaE9cC14x0/7v/8WQZBW8WkvA5kUHjn0Q=
-github.com/civo/civogo v0.7.0/go.mod h1:0RNiA3NDI1imXDADWSCtzcHjUCV02E+SnRLoZKKo1wY=
+github.com/civo/civogo v0.7.2 h1:kaUDRkIM696zRDGsleLChDSV7En7JvBCKtpu9imQC1M=
+github.com/civo/civogo v0.7.2/go.mod h1:Nb15x35xtG7TjCt+Hk20UVIAtMOGMLH2eJoaW9zSj4Y=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=


### PR DESCRIPTION
Pulls in civogo v0.7.2 which auto-paginates every no-arg / wrapped
List* helper that the provider relies on. Affected resources/data
sources whose lookups iterate the full account inventory:

- `civo_reserved_ip` (resource + data) — via `FindIP`/`FindVPCIP`
- `civo_kubernetes_cluster` (resource + data) — via `FindKubernetesCluster`
- `civo_object_store` (resource + data) — via `FindObjectStore`
- `civo_database` (resource + data) — via `FindDatabase`

The follow-up (v0.7.2) over v0.7.1 also closes `ListVPCIPs` and
`ListDatabaseBackup` — the VPC IP fix specifically unblocks
`data "civo_reserved_ip"` since the provider migrated to FindVPCIP
recently. End-to-end verified against staging.

Customer-visible symptom that triggered this: a Terraform plan for
an account with > 20 Reserved IPs in a region could not find one
specific IP, blocking `civo_instance` creation. With v0.7.2 the SDK
iterates server pagination transparently — no caller-side changes
needed for the data lookups.

Also bumps the go.mod `go` directive 1.25.8 -> 1.25.10 (transitively
required by civogo v0.7.2 to clear stdlib advisories from https://github.com/civo/civogo/pull/286).