### PR TITLE
ci: pin goreleaser to 2.15.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,9 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: "1.25.1"
+          version: "2.15.3"
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,7 +23,8 @@ builds:
     ldflags:
       - -s -w -X github.com/civo/terraform-provider-civo/civo.ProviderVersion={{.Version}}
 archives:
-- format: zip
+- formats:
+    - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
GoReleaser `2.16.0` changed `goreleaser check` to exit non-zero whenever the config uses deprecated properties, even when it is otherwise valid (`configuration is valid, but uses deprecated properties`). Since our `.goreleaser.yml` still uses `brews` and `dockers`, the **GoReleaser Check** workflow now fails on every push to master (CI resolves `~> v2` to `2.16.0`).

This pins both `goreleaser-check.yml` and `release.yml` to `2.15.3`, which treats these as warnings and exits `0`, restoring a green pipeline.

The config itself is unchanged and still valid. We will migrate the deprecated properties (`brews` → `homebrew_casks`, `dockers` → `dockers_v2`) and unpin the version in an upcoming release.

Same fix as https://github.com/civo/cli/pull/591