### PR TITLE
fix: prevent nil pointer panic in network/firewall data sources

### DIFF
--- a/civo/firewall/datasource_firewall.go
+++ b/civo/firewall/datasource_firewall.go
@@ -79,6 +79,10 @@ func dataSourceFirewallRead(_ context.Context, d *schema.ResourceData, m interfa
 		foundFirewall = firewall
 	}
 
+	if foundFirewall == nil {
+		return diag.Errorf("[ERR] firewall not found; specify a valid id or name")
+	}
+
 	d.SetId(foundFirewall.ID)
 	d.Set("name", foundFirewall.Name)
 	d.Set("network_id", foundFirewall.NetworkID)

--- a/civo/kubernetes/resource_kubernetes_cluster_nodepool_test.go
+++ b/civo/kubernetes/resource_kubernetes_cluster_nodepool_test.go
@@ -196,5 +196,3 @@ func TestFlattenNodePool(t *testing.T) {
 		})
 	}
 }
-
-

--- a/civo/network/datasource_network.go
+++ b/civo/network/datasource_network.go
@@ -26,21 +26,20 @@ func DataSourceNetwork() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.NoZeroValues,
-				AtLeastOneOf: []string{"id", "label", "region"},
+				AtLeastOneOf: []string{"id", "label"},
 			},
 			"label": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.NoZeroValues,
-				AtLeastOneOf: []string{"id", "label", "region"},
+				AtLeastOneOf: []string{"id", "label"},
 				Description:  "The label of an existing network",
 			},
 			"region": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.NoZeroValues,
-				AtLeastOneOf: []string{"id", "label", "region"},
-				Description:  "The region of an existing network",
+				Description:  "The region an existing network lives in; used to scope the lookup by id or label",
 			},
 			// Computed resource
 			"name": {
@@ -83,6 +82,10 @@ func dataSourceNetworkRead(_ context.Context, d *schema.ResourceData, m interfac
 		}
 
 		foundNetwork = network
+	}
+
+	if foundNetwork == nil {
+		return diag.Errorf("[ERR] network not found; specify a valid id or label")
 	}
 
 	d.SetId(foundNetwork.ID)

--- a/civo/network/datasource_network_unit_test.go
+++ b/civo/network/datasource_network_unit_test.go
@@ -1,0 +1,66 @@
+package network
+
+import (
+	"context"
+	"testing"
+
+	"github.com/civo/civogo"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestDataSourceNetworkRead_regionOnlyDoesNotPanic is a regression test for the
+// crash reported against provider v1.0.45/v1.2.5, where a config supplying only
+// `region` (e.g. `data "civo_network" "x" { region = var.region }`) caused a
+// nil pointer dereference: neither the id nor the label branch ran, foundNetwork
+// stayed nil, and d.SetId(foundNetwork.ID) segfaulted, taking down the plugin.
+//
+// The read must now surface a clean diagnostic instead of panicking.
+func TestDataSourceNetworkRead_regionOnlyDoesNotPanic(t *testing.T) {
+	client, server, err := civogo.NewClientForTesting(map[string]string{})
+	if err != nil {
+		t.Fatalf("failed to build test client: %s", err)
+	}
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, DataSourceNetwork().Schema, map[string]interface{}{
+		"region": "LON1",
+	})
+
+	diags := dataSourceNetworkRead(context.Background(), d, client)
+
+	if !diags.HasError() {
+		t.Fatal("expected an error when only region is provided, got none")
+	}
+}
+
+// TestDataSourceNetworkRead_byID verifies the happy path still populates the
+// data source from an id lookup after the nil guard was added.
+func TestDataSourceNetworkRead_byID(t *testing.T) {
+	client, server, err := civogo.NewClientForTesting(map[string]string{
+		"/v2/vpc/networks": `[{"id":"net-1234","name":"my-net","label":"my-net","default":true}]`,
+	})
+	if err != nil {
+		t.Fatalf("failed to build test client: %s", err)
+	}
+	defer server.Close()
+
+	d := schema.TestResourceDataRaw(t, DataSourceNetwork().Schema, map[string]interface{}{
+		"id":     "net-1234",
+		"region": "LON1",
+	})
+
+	diags := dataSourceNetworkRead(context.Background(), d, client)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+	if got := d.Id(); got != "net-1234" {
+		t.Errorf("id = %q, want %q", got, "net-1234")
+	}
+	if got := d.Get("name").(string); got != "my-net" {
+		t.Errorf("name = %q, want %q", got, "my-net")
+	}
+	if got := d.Get("default").(bool); !got {
+		t.Errorf("default = %v, want true", got)
+	}
+}


### PR DESCRIPTION
## Problem

Reported via Slack — the provider (v1.0.45 and still on v1.2.5) crashes with a `SIGSEGV` when the `civo_network` data source is used with only `region`:

```hcl
data "civo_network" "custom_network" {
  region = var.region
}
```

```
panic: runtime error: invalid memory address or nil pointer dereference
... civo/network/datasource_network.go:88 dataSourceNetworkRead
```

## Root cause

The schema advertised `region` as a valid standalone selector (`AtLeastOneOf: ["id", "label", "region"]`), so a region-only config passed validation. But `dataSourceNetworkRead` only ever assigns `foundNetwork` in the `id` and `label` branches — there is no (and semantically can't be a) "look up a network by region alone" path. With neither `id` nor `label` set, `foundNetwork` stays `nil` and `d.SetId(foundNetwork.ID)` dereferences nil, panicking and taking the whole plugin process down. (The concurrent `civo_firewall` "Request cancelled" error in the report was collateral from the plugin dying, not an independent crash.)

## Fix

- **Schema:** drop `region` from `AtLeastOneOf`, leaving `["id", "label"]`. `region` is now a plain optional scoping field, so a region-only config is rejected at plan time with a clear message instead of crashing at apply.
- **Nil guard:** return a diagnostic if the lookup produced no network, before dereferencing — defence-in-depth against any future schema change.
- **Firewall:** the `civo_firewall` data source has the identical unguarded `d.SetId(foundFirewall.ID)` pattern (saved today only by its `ExactlyOneOf` constraint). Added the matching guard for consistency.

## Tests

New white-box unit tests (no live API — uses `civogo.NewClientForTesting`):

- `TestDataSourceNetworkRead_regionOnlyDoesNotPanic` — region-only input returns a diagnostic instead of panicking. Verified this test panics without the guard and passes with it.
- `TestDataSourceNetworkRead_byID` — id lookup happy path still populates `id`/`name`/`default`.

`go build ./...`, `go vet`, and both tests pass.