### PR TITLE
fix(384): lower minimum DNS record TTL to 60

### DIFF
--- a/civo/dns/resource_dns_domain_record.go
+++ b/civo/dns/resource_dns_domain_record.go
@@ -55,8 +55,8 @@ func ResourceDNSDomainRecord() *schema.Resource {
 			"ttl": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(600, 3600),
-				Description:  "How long caching DNS servers should cache this record for, in seconds (the minimum is 600 and the default if unspecified is 600)",
+				ValidateFunc: validation.IntBetween(60, 3600),
+				Description:  "How long caching DNS servers should cache this record for, in seconds (the minimum is 60 and the default if unspecified is 600)",
 			},
 			// Computed resource
 			"account_id": {

--- a/docs/resources/dns_domain_record.md
+++ b/docs/resources/dns_domain_record.md
@@ -66,7 +66,7 @@ resource "civo_dns_domain_record" "www" {
 
 - `domain_id` (String) ID from domain name
 - `name` (String) The portion before the domain name (e.g. www) or an @ for the apex/root domain (you cannot use an A record with an amex/root domain)
-- `ttl` (Number) How long caching DNS servers should cache this record for, in seconds (the minimum is 600 and the default if unspecified is 600)
+- `ttl` (Number) How long caching DNS servers should cache this record for, in seconds (the minimum is 60 and the default if unspecified is 600)
 - `type` (String) The choice of RR type from a, cname, mx or txt
 - `value` (String) The IP address (A or MX), hostname (CNAME or MX) or text value (TXT) to serve for this record
 


### PR DESCRIPTION
Fixes #384

The DNS domain record resource validated `ttl` with `IntBetween(600, 3600)`, rejecting any value below 600. The Web UI and `external-dns` accept a minimum of 60, so valid records could not be managed via Terraform.

This lowers the minimum to 60 to match the other environments and updates the field description and docs accordingly.