### PR TITLE
fix: scope API client per-region to avoid shared-client data race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ localdev:
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -race -timeout=30s -parallel=4
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/civo/database/datasource_database.go
+++ b/civo/database/datasource_database.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -108,7 +109,7 @@ func dataSourceDatabaseRead(_ context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundDatabase *civogo.Database

--- a/civo/database/resource_database.go
+++ b/civo/database/resource_database.go
@@ -127,7 +127,7 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] configuring the database %s", d.Get("name").(string))
@@ -208,7 +208,7 @@ func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	_, err := apiClient.FindDatabase(d.Id())
@@ -250,7 +250,7 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retriving the Database %s", d.Id())
@@ -288,7 +288,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the Database %s", d.Id())

--- a/civo/disk/datasource_disk_image.go
+++ b/civo/disk/datasource_disk_image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/civo/civogo"
 	"github.com/civo/terraform-provider-civo/internal/datalist"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -48,7 +49,7 @@ func getDiskimages(m interface{}, extra map[string]interface{}) ([]interface{}, 
 	}
 
 	if region != "" {
-		apiClient.Region = region
+		apiClient = utils.RegionalClient(apiClient, region)
 	}
 
 	templateDiskList := []TemplateDisk{}

--- a/civo/firewall/datasource_firewall.go
+++ b/civo/firewall/datasource_firewall.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -56,7 +57,7 @@ func dataSourceFirewallRead(_ context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundFirewall *civogo.Firewall

--- a/civo/firewall/resource_firewall.go
+++ b/civo/firewall/resource_firewall.go
@@ -120,7 +120,7 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	createDefaultRules := d.Get("create_default_rules").(bool)
@@ -186,7 +186,7 @@ func resourceFirewallRead(_ context.Context, d *schema.ResourceData, m interface
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retriving the firewall %s", d.Id())
@@ -225,7 +225,7 @@ func resourceFirewallUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	if d.HasChange("name") {
@@ -318,7 +318,7 @@ func resourceFirewallDelete(_ context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	firewallID := d.Id()

--- a/civo/instances/datasource_instance.go
+++ b/civo/instances/datasource_instance.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -146,7 +147,7 @@ func dataSourceInstanceRead(_ context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundImage *civogo.Instance

--- a/civo/instances/datasource_instances.go
+++ b/civo/instances/datasource_instances.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/civo/civogo"
 	"github.com/civo/terraform-provider-civo/internal/datalist"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -43,7 +44,7 @@ func getDataSourceInstances(m interface{}, extra map[string]interface{}) ([]inte
 	}
 
 	if region != "" {
-		apiClient.Region = region
+		apiClient = utils.RegionalClient(apiClient, region)
 	}
 
 	var instance []interface{}

--- a/civo/instances/resource_instance.go
+++ b/civo/instances/resource_instance.go
@@ -207,7 +207,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] configuring the instance %s", d.Get("hostname").(string))
@@ -370,7 +370,7 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, m interface
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retriving the instance %s", d.Id())
@@ -447,7 +447,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	// check if the size change if change we send to resize the instance
@@ -609,7 +609,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the instance %s", d.Id())

--- a/civo/instances/resource_instance_reserved_ip_assignment.go
+++ b/civo/instances/resource_instance_reserved_ip_assignment.go
@@ -53,7 +53,7 @@ func resourceInstanceReservedIPCreate(ctx context.Context, d *schema.ResourceDat
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	// We check if the instance is valid and if it is not we return an error
@@ -115,7 +115,7 @@ func resourceInstanceReservedIPRead(_ context.Context, d *schema.ResourceData, m
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	instanceID := d.Get("instance_id").(string)
@@ -141,7 +141,7 @@ func resourceInstanceReservedIPDelete(ctx context.Context, d *schema.ResourceDat
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	reservedIP := d.Get("reserved_ip_id").(string)

--- a/civo/ip/resource_reserved_ip.go
+++ b/civo/ip/resource_reserved_ip.go
@@ -54,7 +54,7 @@ func resourceReservedIPCreate(ctx context.Context, d *schema.ResourceData, m int
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] creating the new ip address %s", d.Get("name").(string))
@@ -101,7 +101,7 @@ func resourceReservedIPRead(_ context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retriving the ip address %s", d.Id())
@@ -128,7 +128,7 @@ func resourceReservedIPUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	if d.HasChange("name") {
@@ -151,7 +151,7 @@ func resourceReservedIPDelete(_ context.Context, d *schema.ResourceData, m inter
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the ip resource %s", d.Id())

--- a/civo/kubernetes/datasource_kubernetes_cluster.go
+++ b/civo/kubernetes/datasource_kubernetes_cluster.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -163,7 +164,7 @@ func dataSourceKubernetesClusterRead(_ context.Context, d *schema.ResourceData, 
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundCluster *civogo.KubernetesCluster

--- a/civo/kubernetes/resource_kubernetes_cluster.go
+++ b/civo/kubernetes/resource_kubernetes_cluster.go
@@ -219,7 +219,7 @@ func resourceKubernetesClusterCreate(ctx context.Context, d *schema.ResourceData
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] configuring a new kubernetes cluster %s", d.Get("name").(string))
@@ -365,7 +365,7 @@ func resourceKubernetesClusterRead(_ context.Context, d *schema.ResourceData, m 
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retrieving the kubernetes cluster %s", d.Id())
@@ -421,7 +421,7 @@ func resourceKubernetesClusterUpdate(ctx context.Context, d *schema.ResourceData
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	config := &civogo.KubernetesClusterConfig{}
@@ -620,7 +620,7 @@ func resourceKubernetesClusterDelete(ctx context.Context, d *schema.ResourceData
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the kubernetes cluster %s", d.Id())

--- a/civo/kubernetes/resource_kubernetes_cluster_nodepool.go
+++ b/civo/kubernetes/resource_kubernetes_cluster_nodepool.go
@@ -45,7 +45,7 @@ func resourceKubernetesClusterNodePoolCreate(ctx context.Context, d *schema.Reso
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	clusterID := d.Get("cluster_id").(string)
@@ -204,7 +204,7 @@ func resourceKubernetesClusterNodePoolUpdate(ctx context.Context, d *schema.Reso
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	old, new := d.GetChange("size")
@@ -281,7 +281,7 @@ func resourceKubernetesClusterNodePoolDelete(ctx context.Context, d *schema.Reso
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the kubernetes cluster %s", d.Id())
@@ -331,7 +331,7 @@ func resourceKubernetesClusterNodePoolImport(d *schema.ResourceData, m interface
 		}
 
 		currentRegionCode := region.Code
-		apiClient.Region = currentRegionCode
+		apiClient = utils.RegionalClient(apiClient, currentRegionCode)
 
 		log.Printf("[INFO] Retriving the node pool %s from region %s", nodePoolID, currentRegionCode)
 		respPool, err := apiClient.GetKubernetesClusterPool(clusterID, nodePoolID)

--- a/civo/loadbalancer/datasource_loadbalancer.go
+++ b/civo/loadbalancer/datasource_loadbalancer.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -128,7 +129,7 @@ func dataSourceLoadBalancerRead(_ context.Context, d *schema.ResourceData, m int
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var searchBy string

--- a/civo/network/datasource_network.go
+++ b/civo/network/datasource_network.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -74,7 +75,7 @@ func dataSourceNetworkRead(_ context.Context, d *schema.ResourceData, m interfac
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundNetwork *civogo.Network

--- a/civo/network/datasource_vpc_subnet.go
+++ b/civo/network/datasource_vpc_subnet.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -65,7 +66,7 @@ func dataSourceVPCSubnetRead(_ context.Context, d *schema.ResourceData, m interf
 	apiClient := m.(*civogo.Client)
 
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	networkID := d.Get("network_id").(string)

--- a/civo/network/resource_network.go
+++ b/civo/network/resource_network.go
@@ -114,7 +114,7 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] creating the new network %s", d.Get("label").(string))
@@ -164,7 +164,7 @@ func resourceNetworkRead(_ context.Context, d *schema.ResourceData, m interface{
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	CurrentNetwork := civogo.Network{}
@@ -202,7 +202,7 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	if d.HasChange("label") {
@@ -234,7 +234,7 @@ func resourceNetworkDelete(_ context.Context, d *schema.ResourceData, m interfac
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	networkID := d.Id()

--- a/civo/network/resource_vpc_subnet.go
+++ b/civo/network/resource_vpc_subnet.go
@@ -66,7 +66,7 @@ func resourceVPCSubnetCreate(ctx context.Context, d *schema.ResourceData, m inte
 	apiClient := m.(*civogo.Client)
 
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	networkID := d.Get("network_id").(string)
@@ -89,7 +89,7 @@ func resourceVPCSubnetRead(_ context.Context, d *schema.ResourceData, m interfac
 	apiClient := m.(*civogo.Client)
 
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	networkID := d.Get("network_id").(string)
@@ -117,7 +117,7 @@ func resourceVPCSubnetDelete(_ context.Context, d *schema.ResourceData, m interf
 	apiClient := m.(*civogo.Client)
 
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	networkID := d.Get("network_id").(string)

--- a/civo/objectstorage/datasource_object_store.go
+++ b/civo/objectstorage/datasource_object_store.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -67,7 +68,7 @@ func dataSourceObjectStoreRead(ctx context.Context, d *schema.ResourceData, m in
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundStore *civogo.ObjectStore

--- a/civo/objectstorage/datasource_object_store_credentials.go
+++ b/civo/objectstorage/datasource_object_store_credentials.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -62,7 +63,7 @@ func dataSourceObjectStoreCredentialRead(ctx context.Context, d *schema.Resource
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundStoreCredential *civogo.ObjectStoreCredential

--- a/civo/objectstorage/resource_object_store.go
+++ b/civo/objectstorage/resource_object_store.go
@@ -73,7 +73,7 @@ func resourceObjectStoreCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] configuring the Object Store %s", d.Get("name").(string))
@@ -125,7 +125,7 @@ func resourceObjectStoreRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retriving the Object Store %s", d.Id())
@@ -155,7 +155,7 @@ func resourceObjectStoreUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	_, err := apiClient.FindObjectStore(d.Id())
@@ -186,7 +186,7 @@ func resourceObjectStoreDelete(ctx context.Context, d *schema.ResourceData, m in
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the Object Store %s", d.Id())

--- a/civo/objectstorage/resource_object_store_credentials.go
+++ b/civo/objectstorage/resource_object_store_credentials.go
@@ -68,7 +68,7 @@ func resourceObjectStoreCredentialCreate(ctx context.Context, d *schema.Resource
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] configuring the Object Store Credential %s", d.Get("name").(string))
@@ -124,7 +124,7 @@ func resourceObjectStoreCredentialRead(ctx context.Context, d *schema.ResourceDa
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retriving the Object Store Credential %s", d.Id())
@@ -151,7 +151,7 @@ func resourceObjectStoreCredentialUpdate(ctx context.Context, d *schema.Resource
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	_, err := apiClient.FindObjectStoreCredential(d.Id())
@@ -188,7 +188,7 @@ func resourceObjectStoreCredentialDelete(ctx context.Context, d *schema.Resource
 
 	// overwrite the region if it is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the Object Store Credential %s", d.Id())

--- a/civo/volume/datasource_volume.go
+++ b/civo/volume/datasource_volume.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -70,7 +71,7 @@ func dataSourceVolumeRead(_ context.Context, d *schema.ResourceData, m any) diag
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	var foundVolume *civogo.Volume

--- a/civo/volume/datasource_volumetype.go
+++ b/civo/volume/datasource_volumetype.go
@@ -2,7 +2,9 @@ package volume
 
 import (
 	"context"
+
 	"github.com/civo/civogo"
+	"github.com/civo/terraform-provider-civo/internal/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -34,7 +36,7 @@ func dataSourceCivoVolumeTypeRead(_ context.Context, d *schema.ResourceData, m i
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		client.Region = region.(string)
+		client = utils.RegionalClient(client, region.(string))
 	}
 
 	// Get the name of the volume type from the Terraform configuration

--- a/civo/volume/resource_volume.go
+++ b/civo/volume/resource_volume.go
@@ -69,7 +69,7 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] configuring the volume %s", d.Get("name").(string))
@@ -126,7 +126,7 @@ func resourceVolumeRead(_ context.Context, d *schema.ResourceData, m interface{}
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retrieving the volume %s", d.Id())
@@ -155,7 +155,7 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 
 	// overwrite the region if is defined in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] retrieving the volume %s", d.Id())
@@ -220,7 +220,7 @@ func resourceVolumeDelete(_ context.Context, d *schema.ResourceData, m interface
 
 	// overwrite the region if is define in the datasource
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	log.Printf("[INFO] deleting the volume %s", d.Id())
@@ -246,7 +246,7 @@ func resourceVolumeImport(d *schema.ResourceData, m interface{}) ([]*schema.Reso
 		}
 
 		currentRegion := region.Code
-		apiClient.Region = currentRegion
+		apiClient = utils.RegionalClient(apiClient, currentRegion)
 
 		volumes, err := apiClient.ListVolumes()
 		if err != nil {

--- a/civo/volume/resource_volume_attachment.go
+++ b/civo/volume/resource_volume_attachment.go
@@ -62,7 +62,7 @@ func resourceVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	instanceID := d.Get("instance_id").(string)
@@ -131,7 +131,7 @@ func resourceVolumeAttachmentRead(_ context.Context, d *schema.ResourceData, m i
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	instanceID := d.Get("instance_id").(string)
@@ -162,7 +162,7 @@ func resourceVolumeAttachmentDelete(_ context.Context, d *schema.ResourceData, m
 
 	// overwrite the region if it's defined
 	if region, ok := d.GetOk("region"); ok {
-		apiClient.Region = region.(string)
+		apiClient = utils.RegionalClient(apiClient, region.(string))
 	}
 
 	volumeID := d.Get("volume_id").(string)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -349,3 +349,14 @@ func CheckFileSize(path string) error {
 	}
 	return nil
 }
+
+// RegionalClient returns a shallow copy of the API client scoped to the given
+// region. Resources must use this instead of mutating apiClient.Region directly:
+// the provider shares a single *civogo.Client across all resources, and Terraform
+// runs resource operations concurrently, so mutating the shared client's Region
+// races and can send requests to the wrong region.
+func RegionalClient(apiClient *civogo.Client, region string) *civogo.Client {
+	c := *apiClient
+	c.Region = region
+	return &c
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,6 +1,12 @@
 package utils
 
-import "testing"
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/civo/civogo"
+)
 
 func TestIgnoreCaseDiff(t *testing.T) {
 	tests := []struct {
@@ -78,5 +84,51 @@ func TestIgnoreCaseDiff(t *testing.T) {
 				t.Errorf("IgnoreCaseDiff(%q, %q) = %v, want %v", tt.old, tt.new, got, tt.suppress)
 			}
 		})
+	}
+}
+
+func TestRegionalClient(t *testing.T) {
+	shared := &civogo.Client{Region: "lon1", APIKey: "secret"}
+
+	scoped := RegionalClient(shared, "fra1")
+
+	if scoped.Region != "fra1" {
+		t.Errorf("scoped.Region = %q, want %q", scoped.Region, "fra1")
+	}
+	if scoped == shared {
+		t.Error("RegionalClient returned the same pointer; it must return a copy")
+	}
+	if scoped.APIKey != shared.APIKey {
+		t.Errorf("scoped.APIKey = %q, want %q (copy must carry over other fields)", scoped.APIKey, shared.APIKey)
+	}
+	if shared.Region != "lon1" {
+		t.Errorf("shared.Region was mutated to %q; RegionalClient must not touch the shared client", shared.Region)
+	}
+}
+
+// TestRegionalClientConcurrent reproduces the scenario from issue #395: many
+// resources scoping the single shared client to different regions at the same
+// time (as Terraform does under -parallelism). Each goroutine must see its own
+// region. Run with -race to catch any regression back to mutating the shared
+// client's Region field.
+func TestRegionalClientConcurrent(t *testing.T) {
+	shared := &civogo.Client{Region: "lon1", APIKey: "secret"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			region := fmt.Sprintf("region-%d", i)
+			scoped := RegionalClient(shared, region)
+			if scoped.Region != region {
+				t.Errorf("goroutine %d: scoped.Region = %q, want %q", i, scoped.Region, region)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if shared.Region != "lon1" {
+		t.Errorf("shared.Region = %q after concurrent scoping, want %q", shared.Region, "lon1")
 	}
 }


### PR DESCRIPTION
## Problem

Creating or destroying resources across multiple regions in a single Terraform run intermittently fails with errors such as `DatabaseNetworkNotFoundError: Failed to find the network within the internal database` (#395).

## Root cause

The provider builds a single `*civogo.Client` in `providerConfigure` and hands that same pointer to every resource as `meta`. Each resource then mutated `apiClient.Region` directly on that shared client. civogo attaches this field to every request as the `region` query param.

Terraform applies/destroys resources concurrently (default `-parallelism=10`), so resources targeting different regions race on the single shared `Region` field. A request meant for one region can go out tagged with another, which is why the failure is timing-dependent and why removing resources one-by-one from state works around it.

## Fix

Add `utils.RegionalClient`, which returns a region-scoped shallow copy of the client, and use it in place of mutating the shared client's `Region` field across all resources and data sources. Each operation now works on its own copy; the shared client is never mutated. This also removes a secondary shared-state race on the client's `LastJSONResponse` field.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- unit test suite passes

Fixes #395