### PR TITLE
docs(344): clarify write_kubeconfig is required to populate kubeconfig

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -113,6 +113,8 @@ civo kubernetes version
 
 ~> **Careful!** The `kubeconfig` file will have the credentials to your cluster, take care not to commit it to a public repository or store it somewhere unsafe. 
 
+~> **Important:** You must set `write_kubeconfig = true` on the resource (it defaults to `false`) for the `kubeconfig` attribute to be populated. When it is `false`, `civo_kubernetes_cluster.example.kubeconfig` is empty, so references like the `local_file` below will not work. This opt-in avoids storing cluster credentials in the Terraform state file unless you explicitly ask for it.
+
 
 ```terraform
 provider "civo" {
@@ -241,7 +243,7 @@ Optional:
 - `dns_entry` (String) The DNS name of the cluster
 - `id` (String) The ID of this resource.
 - `installed_applications` (List of Object) (see [below for nested schema](#nestedatt--installed_applications))
-- `kubeconfig` (String, Sensitive) The kubeconfig of the cluster
+- `kubeconfig` (String, Sensitive) The kubeconfig of the cluster. Only populated when `write_kubeconfig = true` is set on the resource; otherwise it is empty
 - `master_ip` (String) The IP address of the master node
 - `ready` (Boolean) When cluster is ready, this will return `true`
 - `status` (String) Status of the cluster


### PR DESCRIPTION
Closes #344

Since #309, the `kubeconfig` attribute is only written to the Terraform state when `write_kubeconfig = true` (it defaults to `false`). This was a major detail missing from the docs — users referencing `civo_kubernetes_cluster.example.kubeconfig` without it get an empty value.

The example already sets `write_kubeconfig = true` (added in #321/#339). This adds the missing explanation:

- A note in the kubeconfig example section explaining that `write_kubeconfig = true` is required for the attribute to be populated, and why it defaults to off.
- A clarification on the `kubeconfig` attribute reference.